### PR TITLE
Adjustments to grammar for syntax highlighting (up to grammar v0.23.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Julia tree-sitter grammar will be automatically downloaded and compiled when a
 Julia file is opened using the major mode `julia-ts-mode`. For more information
 on how to install and configure `treesit-auto`, check the package documentation.
 
+### Upgrading grammar after a package update
+
+Note that the [tree-sitter grammar for
+Julia](https://github.com/tree-sitter/tree-sitter-julia) is under active
+development, and breaking changes are often introduced between versions. To
+provide maximum compatibility, the exact version of the grammar library is fixed
+in `julia-ts-mode.el`, with planned regular updates to both the grammar version
+and the tree-sitter queries built on top of it. However, the grammar library
+itself isn't updated automatically by Emacs. If, after a `julia-ts-mode` package
+update, you get some quirky tree-sitter error messages, and font-locking fails
+to work in a `julia-ts-mode` buffer, run `M-x treesit-install-language-grammar
+RET julia RET` to upgrade the grammar library. This should resolve the issues.
+
 # LSP Configuration
 
 This mode is derived from `julia-mode`. Hence, most of the feature available for

--- a/julia-ts-mode.el
+++ b/julia-ts-mode.el
@@ -153,7 +153,8 @@ Otherwise, the indentation is:
         value: (identifier) "." (identifier) @font-lock-variable-name-face)))
      (local_statement (identifier) @font-lock-variable-name-face)
      (let_statement :anchor (identifier) @font-lock-variable-name-face)
-     (let_statement "," :anchor (identifier) @font-lock-variable-name-face)
+     ((let_statement _ @comma :anchor (identifier) @font-lock-variable-name-face)
+      (:equal "," @comma))
      (let_binding :anchor (identifier) @font-lock-variable-name-face)
      (global_statement (identifier) @font-lock-variable-name-face))
 

--- a/julia-ts-mode.el
+++ b/julia-ts-mode.el
@@ -122,13 +122,17 @@ Otherwise, the indentation is:
   '((t :inherit font-lock-constant-face))
   "Face for quoted Julia symbols in `julia-ts-mode', e.g. :foo.")
 
+(defface julia-ts-keyword-argument-face
+  '((t :inherit font-lock-constant-face))
+  "Face for keyword argument names in `julia-ts-mode'.")
+
 (defface julia-ts-interpolation-expression-face
   '((t :inherit font-lock-constant-face))
-  "Face for interpolation expressions in `julia-ts-mode', e.g. :foo.")
+  "Face for interpolation expressions in `julia-ts-mode', e.g. $foo.")
 
 (defface julia-ts-string-interpolation-face
   '((t :inherit font-lock-constant-face :weight bold))
-  "Face for string interpolations in `julia-ts-mode', e.g. :foo.")
+  "Face for string interpolations in `julia-ts-mode', e.g. \"$foo\".")
 
 (defvar julia-ts--keywords
   '("baremodule" "begin" "catch" "const" "do" "else" "elseif" "end" "export"
@@ -140,7 +144,7 @@ Otherwise, the indentation is:
   (treesit-font-lock-rules
    :language 'julia
    :feature 'assignment
-   `((assignment (identifier) @font-lock-variable-name-face (_))
+   `((assignment :anchor [(identifier) (operator)] @font-lock-variable-name-face)
      (assignment
       :anchor
       (field_expression
@@ -156,15 +160,15 @@ Otherwise, the indentation is:
      ((let_statement _ @comma :anchor (identifier) @font-lock-variable-name-face)
       (:equal "," @comma))
      (let_binding :anchor (identifier) @font-lock-variable-name-face)
-     (global_statement (identifier) @font-lock-variable-name-face))
+     (global_statement (identifier) @font-lock-variable-name-face)
+     (named_argument (identifier) @julia-ts-keyword-argument-face (operator)))
 
    :language 'julia
    :feature 'constant
-   `((named_argument (identifier) @julia-ts-quoted-symbol-face (operator))
-     ((identifier) @font-lock-builtin-face
+   `(((identifier) @font-lock-constant-face
       (:match
-       "^\\(:?NaN\\|NaN16\\|NaN32\\|NaN64\\|Inf\\|Inf16\\|Inf32\\|Inf64\\|nothing\\|missing\\|undef\\)$"
-       @font-lock-builtin-face)))
+       "^\\(NaN\\|NaN16\\|NaN32\\|NaN64\\|Inf\\|Inf16\\|Inf32\\|Inf64\\|nothing\\|missing\\|undef\\)$"
+       @font-lock-constant-face)))
 
    :language 'julia
    :feature 'comment
@@ -228,6 +232,11 @@ Otherwise, the indentation is:
      (assignment
       :anchor
       (call_expression
+       (parenthesized_expression
+        [(identifier) (operator)] @font-lock-function-name-face)))
+     (assignment
+      :anchor
+      (call_expression
        (field_expression
         value: (identifier) "." (identifier) @font-lock-function-name-face)))
      (assignment
@@ -239,7 +248,10 @@ Otherwise, the indentation is:
       (where_expression
        (call_expression
         (field_expression
-         value: (identifier) "." (identifier) @font-lock-function-name-face)))))
+         value: (identifier) "." (identifier) @font-lock-function-name-face))))
+     (assignment
+      :anchor
+      (binary_expression _ (operator) @font-lock-function-name-face)))
 
    :language 'julia
    :feature 'error
@@ -270,24 +282,24 @@ Otherwise, the indentation is:
 
    :language 'julia
    :feature 'operator
-   `((adjoint_expression "'" @font-lock-type-face)
-     (let_binding (operator) @font-lock-type-face)
-     ((for_binding (operator) @font-lock-type-face)
-      (:match "^\\[=∈\\]$" @font-lock-type-face))
-     (arrow_function_expression "->" @font-lock-type-face)
-     (operator) @font-lock-type-face
-     (splat_expression "..." @font-lock-type-face)
-     (ternary_expression ["?" ":"] @font-lock-type-face)
-     (["." "::"] @font-lock-type-face))
+   `((adjoint_expression "'" @font-lock-keyword-face)
+     (let_binding (operator) @font-lock-keyword-face)
+     ((for_binding (operator) @font-lock-keyword-face)
+      (:match "^\\[=∈\\]$" @font-lock-keyword-face))
+     (arrow_function_expression "->" @font-lock-keyword-face)
+     (operator) @font-lock-keyword-face
+     (splat_expression "..." @font-lock-keyword-face)
+     (ternary_expression ["?" ":"] @font-lock-keyword-face)
+     (["." "::"] @font-lock-keyword-face))
 
    :language 'julia
    :feature 'interpolation
    :override 'keep
    `((interpolation_expression
-      "$" @julia-ts-interpolation-expression-face
+      "$" @julia-ts-interpolation-expression-face)
+     (interpolation_expression
       (identifier) @default)
      (interpolation_expression
-      "$" @julia-ts-interpolation-expression-face
       (parenthesized_expression
        "(" @julia-ts-interpolation-expression-face
        _ @default
@@ -333,13 +345,7 @@ Otherwise, the indentation is:
       (curly_expression "{" (identifier) @font-lock-type-face))
      (where_expression
       "where"
-      (curly_expression "{" (binary_expression (identifier) @font-lock-type-face))))
-
-   :language 'julia
-   :feature 'keyword
-   :override t
-   '((((identifier) @font-lock-keyword-face)
-      (:equal "new" @font-lock-keyword-face))))
+      (curly_expression "{" (binary_expression (identifier) @font-lock-type-face)))))
 
   "Tree-sitter font-lock settings for `julia-ts-mode'.")
 

--- a/julia-ts-mode.el
+++ b/julia-ts-mode.el
@@ -40,6 +40,11 @@
 (require 'julia-mode)
 (require 'julia-ts-misc)
 
+;; Fix grammar version to 0.23.0, which is known to be compatible with the
+;; treesitter queries defined in the present version of the mode definition.
+(add-to-list 'treesit-language-source-alist
+             '(julia "https://github.com/tree-sitter/tree-sitter-julia" "v0.23.0"))
+
 (declare-function treesit-parser-create "treesit.c")
 
 (defgroup julia-ts nil

--- a/julia-ts-mode.el
+++ b/julia-ts-mode.el
@@ -338,7 +338,7 @@ Otherwise, the indentation is:
      ((julia-ts--parent-is-and-sibling-not-on-same-line "curly_expression" 1) parent-bol julia-ts-indent-offset)
 
      ;; Align the expressions in the if statement conditions.
-     ((julia-ts--ancestor-is "if_statement") parent-bol julia-ts-indent-offset)
+     ((parent-is "if_statement") parent-bol julia-ts-indent-offset)
 
      ;; For all other expressions, keep the indentation as the parent.
      ((parent-is "_expression") parent 0)

--- a/julia-ts-mode.el
+++ b/julia-ts-mode.el
@@ -192,7 +192,17 @@ Otherwise, the indentation is:
       :anchor
       (call_expression
        (field_expression
-        value: (identifier) "." (identifier) @font-lock-function-name-face))))
+        value: (identifier) "." (identifier) @font-lock-function-name-face)))
+     (assignment
+      :anchor
+      (where_expression
+       (call_expression (identifier) @font-lock-function-name-face)))
+     (assignment
+      :anchor
+      (where_expression
+       (call_expression
+        (field_expression
+         value: (identifier) "." (identifier) @font-lock-function-name-face)))))
 
    :language 'julia
    :feature 'error

--- a/test/ArgTools.jl
+++ b/test/ArgTools.jl
@@ -1,0 +1,338 @@
+module ArgTools
+
+export
+    arg_read,  ArgRead,  arg_readers,
+    arg_write, ArgWrite, arg_writers,
+    arg_isdir, arg_mkdir, @arg_test
+
+import Base: AbstractCmd, CmdRedirect, Process
+
+if isdefined(Base.Filesystem, :prepare_for_deletion)
+    using Base.Filesystem: prepare_for_deletion
+else
+    function prepare_for_deletion(path::AbstractString)
+        try prepare_for_deletion_core(path)
+        catch
+        end
+    end
+    function prepare_for_deletion_core(path::AbstractString)
+        isdir(path) || return
+        chmod(path, filemode(path) | 0o333)
+        for name in readdir(path)
+            path′ = joinpath(path, name)
+            prepare_for_deletion_core(path′)
+        end
+    end
+end
+
+const nolock_docstring = """
+Note: when opening a file, ArgTools will pass `lock = false` to the file `open(...)` call.
+Therefore, the object returned by this function should not be used from multiple threads.
+This restriction may be relaxed in the future, which would not break any working code.
+"""
+
+if VERSION ≥ v"1.5"
+    open_nolock(args...; kws...) = open(args...; kws..., lock=false)
+else
+    open_nolock(args...; kws...) = open(args...; kws...)
+end
+
+## main API ##
+
+"""
+    ArgRead = Union{AbstractString, AbstractCmd, IO}
+
+The `ArgRead` types is a union of the types that the `arg_read` function knows
+how to convert into readable IO handles. See [`arg_read`](@ref) for details.
+"""
+const ArgRead = Union{AbstractString, AbstractCmd, IO}
+
+"""
+    ArgWrite = Union{AbstractString, AbstractCmd, IO}
+
+The `ArgWrite` types is a union of the types that the `arg_write` function knows
+how to convert into writeable IO handles, except for `Nothing` which `arg_write`
+handles by generating a temporary file. See [`arg_write`](@ref) for details.
+"""
+const ArgWrite = Union{AbstractString, AbstractCmd, IO}
+
+"""
+    arg_read(f::Function, arg::ArgRead) -> f(arg_io)
+
+The `arg_read` function accepts an argument `arg` that can be any of these:
+
+- `AbstractString`: a file path to be opened for reading
+- `AbstractCmd`: a command to be run, reading from its standard output
+- `IO`: an open IO handle to be read from
+
+Whether the body returns normally or throws an error, a path which is opened
+will be closed before returning from `arg_read` and an `IO` handle will be
+flushed but not closed before returning from `arg_read`.
+
+$(nolock_docstring)
+"""
+arg_read(f::Function, arg::AbstractString) = open_nolock(f, arg)
+arg_read(f::Function, arg::ArgRead) = open(f, arg)
+arg_read(f::Function, arg::IO) = f(arg)
+
+"""
+    arg_write(f::Function, arg::ArgWrite) -> arg
+    arg_write(f::Function, arg::Nothing) -> tempname()
+
+The `arg_read` function accepts an argument `arg` that can be any of these:
+
+- `AbstractString`: a file path to be opened for writing
+- `AbstractCmd`: a command to be run, writing to its standard input
+- `IO`: an open IO handle to be written to
+- `Nothing`: a temporary path should be written to
+
+If the body returns normally, a path that is opened will be closed upon
+completion; an IO handle argument is left open but flushed before return. If the
+argument is `nothing` then a temporary path is opened for writing and closed
+open completion and the path is returned from `arg_write`. In all other cases,
+`arg` itself is returned. This is a useful pattern since you can consistently
+return whatever was written, whether an argument was passed or not.
+
+If there is an error during the evaluation of the body, a path that is opened by
+`arg_write` for writing will be deleted, whether it's passed in as a string or a
+temporary path generated when `arg` is `nothing`.
+
+$(nolock_docstring)
+"""
+function arg_write(f::Function, arg::AbstractString)
+    try open_nolock(f, arg, write=true)
+    catch
+        rm(arg, force=true)
+        rethrow()
+    end
+    return arg
+end
+
+function arg_write(f::Function, arg::AbstractCmd)
+    open(f, arg, write=true)
+    return arg
+end
+
+function arg_write(f::Function, arg::Nothing)
+    @static if VERSION ≥ v"1.5"
+        file = tempname()
+        io = open_nolock(file, write=true)
+    else
+        file, io = mktemp()
+    end
+    try f(io)
+    catch
+        close(io)
+        rm(file, force=true)
+        rethrow()
+    end
+    close(io)
+    return file
+end
+
+function arg_write(f::Function, arg::IO)
+    try f(arg)
+    finally
+        flush(arg)
+    end
+    return arg
+end
+
+"""
+    arg_isdir(f::Function, arg::AbstractString) -> f(arg)
+
+The `arg_isdir` function takes `arg` which must be the path to an existing
+directory (an error is raised otherwise) and passes that path to `f` finally
+returning the result of `f(arg)`. This is definitely the least useful tool
+offered by `ArgTools` and mostly exists for symmetry with `arg_mkdir` and to
+give consistent error messages.
+"""
+function arg_isdir(f::Function, arg::AbstractString)
+    isdir(arg) || error("arg_isdir: $(repr(arg)) not a directory")
+    return f(arg)
+end
+
+"""
+    arg_mkdir(f::Function, arg::AbstractString) -> arg
+    arg_mkdir(f::Function, arg::Nothing) -> mktempdir()
+
+The `arg_mkdir` function takes `arg` which must either be one of:
+
+- a path to an already existing empty directory,
+- a non-existent path which can be created as a directory, or
+- `nothing` in which case a temporary directory is created.
+
+In all cases the path to the directory is returned. If an error occurs during
+`f(arg)`, the directory is returned to its original state: if it already existed
+but was empty, it will be emptied; if it did not exist it will be deleted.
+"""
+function arg_mkdir(f::Function, arg::Union{AbstractString, Nothing})
+    existed = false
+    if arg === nothing
+        arg = mktempdir()
+    else
+        st = stat(arg)
+        if !ispath(st)
+            mkdir(arg)
+        elseif !isdir(st)
+            error("arg_mkdir: $(repr(arg)) not a directory")
+        else
+            isempty(readdir(arg)) ||
+                error("arg_mkdir: $(repr(arg)) directory not empty")
+            existed = true
+        end
+    end
+    try f(arg)
+    catch
+        if existed
+            for name in readdir(arg)
+                path = joinpath(arg, name)
+                prepare_for_deletion(path)
+                rm(path, force=true, recursive=true)
+            end
+        else
+            prepare_for_deletion(arg)
+            rm(arg, force=true, recursive=true)
+        end
+        rethrow()
+    end
+    return arg
+end
+
+## test utilities ##
+
+const ARG_READERS = [
+    String      => path -> f -> f(path)
+    Cmd         => path -> f -> f(`cat $path`)
+    CmdRedirect => path -> f -> f(pipeline(path, `cat`))
+    IOStream    => path -> f -> open(f, path)
+    Process     => path -> f -> open(f, `cat $path`)
+]
+
+const ARG_WRITERS = [
+    String      => path -> f -> f(path)
+    Cmd         => path -> f -> f(`tee $path`)
+    CmdRedirect => path -> f -> f(pipeline(`cat`, path))
+    IOStream    => path -> f -> open(f, path, write=true)
+    Process     => path -> f -> open(f, pipeline(`cat`, path), write=true)
+]
+
+@assert all(t <: ArgRead  for t in map(first, ARG_READERS))
+@assert all(t <: ArgWrite for t in map(first, ARG_WRITERS))
+
+"""
+    arg_readers(arg :: AbstractString, [ type = ArgRead ]) do arg::Function
+        ## pre-test setup ##
+        @arg_test arg begin
+            arg :: ArgRead
+            ## test using `arg` ##
+        end
+        ## post-test cleanup ##
+    end
+
+The `arg_readers` function takes a path to be read and a single-argument do
+block, which is invoked once for each test reader type that `arg_read` can
+handle. If the optional `type` argument is given then the do block is only
+invoked for readers that produce arguments of that type.
+
+The `arg` passed to the do block is not the argument value itself, because some
+of test argument types need to be initialized and finalized for each test case.
+Consider an open file handle argument: once you've used it for one test, you
+can't use it again; you need to close it and open the file again for the next
+test. This function `arg` can be converted into an `ArgRead` instance using
+`@arg_test arg begin ... end`.
+"""
+function arg_readers(
+    body::Function,
+    path::AbstractString,
+    type::Type = ArgRead,
+)
+    for (t, reader) in ARG_READERS
+        t <: type || continue
+        body(reader(path))
+    end
+end
+
+"""
+    arg_writers([ type = ArgWrite ]) do path::String, arg::Function
+        ## pre-test setup ##
+        @arg_test arg begin
+            arg :: ArgWrite
+            ## test using `arg` ##
+        end
+        ## post-test cleanup ##
+    end
+
+The `arg_writers` function takes a do block, which is invoked once for each test
+writer type that `arg_write` can handle with a temporary (non-existent) `path`
+and `arg` which can be converted into various writable argument types which
+write to `path`. If the optional `type` argument is given then the do block is
+only invoked for writers that produce arguments of that type.
+
+The `arg` passed to the do block is not the argument value itself, because some
+of test argument types need to be initialized and finalized for each test case.
+Consider an open file handle argument: once you've used it for one test, you
+can't use it again; you need to close it and open the file again for the next
+test. This function `arg` can be converted into an `ArgWrite` instance using
+`@arg_test arg begin ... end`.
+
+There is also an `arg_writers` method that takes a path name like `arg_readers`:
+
+    arg_writers(path::AbstractString, [ type = ArgWrite ]) do arg::Function
+        ## pre-test setup ##
+        @arg_test arg begin
+            # here `arg :: ArgWrite`
+            ## test using `arg` ##
+        end
+        ## post-test cleanup ##
+    end
+
+This method is useful if you need to specify `path` instead of using path name
+generated by `tempname()`. Since `path` is passed from outside of `arg_writers`,
+the path is not an argument to the do block in this form.
+"""
+function arg_writers(
+    body::Function,
+    type::Type = ArgWrite,
+)
+    for (t, writer) in ARG_WRITERS
+        t <: type || continue
+        path = tempname()
+        try body(path, writer(path))
+        finally
+            rm(path, force=true)
+        end
+    end
+end
+
+function arg_writers(
+    body::Function,
+    path::AbstractString,
+    type::Type = ArgWrite,
+)
+    for (t, writer) in ARG_WRITERS
+        t <: type || continue
+        body(writer(path))
+    end
+end
+
+"""
+    @arg_test arg1 arg2 ... body
+
+The `@arg_test` macro is used to convert `arg` functions provided by
+`arg_readers` and `arg_writers` into actual argument values. When you write
+`@arg_test arg body` it is equivalent to `arg(arg -> body)`.
+"""
+macro arg_test(args...)
+    arg_test(args...)
+end
+
+function arg_test(var::Symbol, args...)
+    var = esc(var)
+    body = arg_test(args...)
+    :($var($var -> $body))
+end
+
+arg_test(ex::Expr) = esc(ex)
+
+end # module

--- a/test/ArgTools.jl.faceup
+++ b/test/ArgTools.jl.faceup
@@ -45,7 +45,7 @@ This restriction may be relaxed in the future, which would not break any working
 The `ArgRead` types is a union of the types that the `arg_read` function knows
 how to convert into readable IO handles. See [`arg_read`](@ref) for details.
 """»
-«k:const» «v:ArgRead» = Union{AbstractString, AbstractCmd, IO}
+«k:const» «v:ArgRead» = «t:Union»{«t:AbstractString», «t:AbstractCmd», «t:IO»}
 
 «s:"""
     ArgWrite = Union{AbstractString, AbstractCmd, IO}
@@ -54,7 +54,7 @@ The `ArgWrite` types is a union of the types that the `arg_write` function knows
 how to convert into writeable IO handles, except for `Nothing` which `arg_write`
 handles by generating a temporary file. See [`arg_write`](@ref) for details.
 """»
-«k:const» «v:ArgWrite» = Union{AbstractString, AbstractCmd, IO}
+«k:const» «v:ArgWrite» = «t:Union»{«t:AbstractString», «t:AbstractCmd», «t:IO»}
 
 «s:"""
     arg_read(f::Function, arg::ArgRead) -> f(arg_io)
@@ -166,7 +166,7 @@ In all cases the path to the directory is returned. If an error occurs during
 `f(arg)`, the directory is returned to its original state: if it already existed
 but was empty, it will be emptied; if it did not exist it will be deleted.
 """»
-«k:function» «f:arg_mkdir»(f::«t:Function», arg::«t:Union{AbstractString, Nothing}»)
+«k:function» «f:arg_mkdir»(f::«t:Function», arg::«t:Union»{«t:AbstractString», «t:Nothing»})
     «v:existed» = «c:false»
     «k:if» arg === «b:nothing»
         «v:arg» = mktempdir()

--- a/test/ArgTools.jl.faceup
+++ b/test/ArgTools.jl.faceup
@@ -1,0 +1,338 @@
+«k:module» ArgTools
+
+«k:export»
+    arg_read,  ArgRead,  arg_readers,
+    arg_write, ArgWrite, arg_writers,
+    arg_isdir, arg_mkdir, «:julia-ts-macro-face:@arg_test»
+
+«k:import» Base: AbstractCmd, CmdRedirect, Process
+
+«k:if» isdefined(Base.Filesystem, «:julia-ts-quoted-symbol-face::prepare_for_deletion»)
+    «k:using» Base.Filesystem: prepare_for_deletion
+«k:else»
+    «k:function» «f:prepare_for_deletion»(path::«t:AbstractString»)
+        «k:try» prepare_for_deletion_core(path)
+        «k:catch»
+        «k:end»
+    «k:end»
+    «k:function» «f:prepare_for_deletion_core»(path::«t:AbstractString»)
+        isdir(path) || «k:return»
+        chmod(path, filemode(path) | «c:0o333»)
+        «k:for» name «k:in» readdir(path)
+            «v:path′» = joinpath(path, name)
+            prepare_for_deletion_core(path′)
+        «k:end»
+    «k:end»
+«k:end»
+
+«k:const» «v:nolock_docstring» = «s:"""
+Note: when opening a file, ArgTools will pass `lock = false` to the file `open(...)` call.
+Therefore, the object returned by this function should not be used from multiple threads.
+This restriction may be relaxed in the future, which would not break any working code.
+"""»
+
+«k:if» VERSION ≥ «s:v"1.5"»
+    «f:open_nolock»(args...; kws...) = open(args...; kws..., «:julia-ts-quoted-symbol-face:lock»=«c:false»)
+«k:else»
+    «f:open_nolock»(args...; kws...) = open(args...; kws...)
+«k:end»
+
+«x:## main API ##»
+
+«s:"""
+    ArgRead = Union{AbstractString, AbstractCmd, IO}
+
+The `ArgRead` types is a union of the types that the `arg_read` function knows
+how to convert into readable IO handles. See [`arg_read`](@ref) for details.
+"""»
+«k:const» «v:ArgRead» = Union{AbstractString, AbstractCmd, IO}
+
+«s:"""
+    ArgWrite = Union{AbstractString, AbstractCmd, IO}
+
+The `ArgWrite` types is a union of the types that the `arg_write` function knows
+how to convert into writeable IO handles, except for `Nothing` which `arg_write`
+handles by generating a temporary file. See [`arg_write`](@ref) for details.
+"""»
+«k:const» «v:ArgWrite» = Union{AbstractString, AbstractCmd, IO}
+
+«s:"""
+    arg_read(f::Function, arg::ArgRead) -> f(arg_io)
+
+The `arg_read` function accepts an argument `arg` that can be any of these:
+
+- `AbstractString`: a file path to be opened for reading
+- `AbstractCmd`: a command to be run, reading from its standard output
+- `IO`: an open IO handle to be read from
+
+Whether the body returns normally or throws an error, a path which is opened
+will be closed before returning from `arg_read` and an `IO` handle will be
+flushed but not closed before returning from `arg_read`.
+
+»«:julia-ts-string-interpolation-face:$(»«D:nolock_docstring»«:julia-ts-string-interpolation-face:)»«s:
+"""»
+«f:arg_read»(f::«t:Function», arg::«t:AbstractString») = open_nolock(f, arg)
+«f:arg_read»(f::«t:Function», arg::«t:ArgRead») = open(f, arg)
+«f:arg_read»(f::«t:Function», arg::«t:IO») = f(arg)
+
+«s:"""
+    arg_write(f::Function, arg::ArgWrite) -> arg
+    arg_write(f::Function, arg::Nothing) -> tempname()
+
+The `arg_read` function accepts an argument `arg` that can be any of these:
+
+- `AbstractString`: a file path to be opened for writing
+- `AbstractCmd`: a command to be run, writing to its standard input
+- `IO`: an open IO handle to be written to
+- `Nothing`: a temporary path should be written to
+
+If the body returns normally, a path that is opened will be closed upon
+completion; an IO handle argument is left open but flushed before return. If the
+argument is `nothing` then a temporary path is opened for writing and closed
+open completion and the path is returned from `arg_write`. In all other cases,
+`arg` itself is returned. This is a useful pattern since you can consistently
+return whatever was written, whether an argument was passed or not.
+
+If there is an error during the evaluation of the body, a path that is opened by
+`arg_write` for writing will be deleted, whether it's passed in as a string or a
+temporary path generated when `arg` is `nothing`.
+
+»«:julia-ts-string-interpolation-face:$(»«D:nolock_docstring»«:julia-ts-string-interpolation-face:)»«s:
+"""»
+«k:function» «f:arg_write»(f::«t:Function», arg::«t:AbstractString»)
+    «k:try» open_nolock(f, arg, «:julia-ts-quoted-symbol-face:write»=«c:true»)
+    «k:catch»
+        rm(arg, «:julia-ts-quoted-symbol-face:force»=«c:true»)
+        rethrow()
+    «k:end»
+    «k:return» arg
+«k:end»
+
+«k:function» «f:arg_write»(f::«t:Function», arg::«t:AbstractCmd»)
+    open(f, arg, «:julia-ts-quoted-symbol-face:write»=«c:true»)
+    «k:return» arg
+«k:end»
+
+«k:function» «f:arg_write»(f::«t:Function», arg::«t:Nothing»)
+    «:julia-ts-macro-face:@static» «k:if» VERSION ≥ «s:v"1.5"»
+        «v:file» = tempname()
+        «v:io» = open_nolock(file, «:julia-ts-quoted-symbol-face:write»=«c:true»)
+    «k:else»
+        «v:file», «v:io» = mktemp()
+    «k:end»
+    «k:try» f(io)
+    «k:catch»
+        close(io)
+        rm(file, «:julia-ts-quoted-symbol-face:force»=«c:true»)
+        rethrow()
+    «k:end»
+    close(io)
+    «k:return» file
+«k:end»
+
+«k:function» «f:arg_write»(f::«t:Function», arg::«t:IO»)
+    «k:try» f(arg)
+    «k:finally»
+        flush(arg)
+    «k:end»
+    «k:return» arg
+«k:end»
+
+«s:"""
+    arg_isdir(f::Function, arg::AbstractString) -> f(arg)
+
+The `arg_isdir` function takes `arg` which must be the path to an existing
+directory (an error is raised otherwise) and passes that path to `f` finally
+returning the result of `f(arg)`. This is definitely the least useful tool
+offered by `ArgTools` and mostly exists for symmetry with `arg_mkdir` and to
+give consistent error messages.
+"""»
+«k:function» «f:arg_isdir»(f::«t:Function», arg::«t:AbstractString»)
+    isdir(arg) || error(«s:"arg_isdir: »«:julia-ts-string-interpolation-face:$(»«D:repr(arg)»«:julia-ts-string-interpolation-face:)»«s: not a directory"»)
+    «k:return» f(arg)
+«k:end»
+
+«s:"""
+    arg_mkdir(f::Function, arg::AbstractString) -> arg
+    arg_mkdir(f::Function, arg::Nothing) -> mktempdir()
+
+The `arg_mkdir` function takes `arg` which must either be one of:
+
+- a path to an already existing empty directory,
+- a non-existent path which can be created as a directory, or
+- `nothing` in which case a temporary directory is created.
+
+In all cases the path to the directory is returned. If an error occurs during
+`f(arg)`, the directory is returned to its original state: if it already existed
+but was empty, it will be emptied; if it did not exist it will be deleted.
+"""»
+«k:function» «f:arg_mkdir»(f::«t:Function», arg::«t:Union{AbstractString, Nothing}»)
+    «v:existed» = «c:false»
+    «k:if» arg === «b:nothing»
+        «v:arg» = mktempdir()
+    «k:else»
+        «v:st» = stat(arg)
+        «k:if» !ispath(st)
+            mkdir(arg)
+        «k:elseif» !isdir(st)
+            error(«s:"arg_mkdir: »«:julia-ts-string-interpolation-face:$(»«D:repr(arg)»«:julia-ts-string-interpolation-face:)»«s: not a directory"»)
+        «k:else»
+            isempty(readdir(arg)) ||
+                error(«s:"arg_mkdir: »«:julia-ts-string-interpolation-face:$(»«D:repr(arg)»«:julia-ts-string-interpolation-face:)»«s: directory not empty"»)
+            «v:existed» = «c:true»
+        «k:end»
+    «k:end»
+    «k:try» f(arg)
+    «k:catch»
+        «k:if» existed
+            «k:for» name «k:in» readdir(arg)
+                «v:path» = joinpath(arg, name)
+                prepare_for_deletion(path)
+                rm(path, «:julia-ts-quoted-symbol-face:force»=«c:true», «:julia-ts-quoted-symbol-face:recursive»=«c:true»)
+            «k:end»
+        «k:else»
+            prepare_for_deletion(arg)
+            rm(arg, «:julia-ts-quoted-symbol-face:force»=«c:true», «:julia-ts-quoted-symbol-face:recursive»=«c:true»)
+        «k:end»
+        rethrow()
+    «k:end»
+    «k:return» arg
+«k:end»
+
+«x:## test utilities ##»
+
+«k:const» «v:ARG_READERS» = [
+    String      => path -> f -> f(path)
+    Cmd         => path -> f -> f(«s:`cat »«:julia-ts-string-interpolation-face:$»«D:path»«s:`»)
+    CmdRedirect => path -> f -> f(pipeline(path, «s:`cat`»))
+    IOStream    => path -> f -> open(f, path)
+    Process     => path -> f -> open(f, «s:`cat »«:julia-ts-string-interpolation-face:$»«D:path»«s:`»)
+]
+
+«k:const» «v:ARG_WRITERS» = [
+    String      => path -> f -> f(path)
+    Cmd         => path -> f -> f(«s:`tee »«:julia-ts-string-interpolation-face:$»«D:path»«s:`»)
+    CmdRedirect => path -> f -> f(pipeline(«s:`cat`», path))
+    IOStream    => path -> f -> open(f, path, «:julia-ts-quoted-symbol-face:write»=«c:true»)
+    Process     => path -> f -> open(f, pipeline(«s:`cat`», path), «:julia-ts-quoted-symbol-face:write»=«c:true»)
+]
+
+«:julia-ts-macro-face:@assert» all(t <: ArgRead  «k:for» t «k:in» map(first, ARG_READERS))
+«:julia-ts-macro-face:@assert» all(t <: ArgWrite «k:for» t «k:in» map(first, ARG_WRITERS))
+
+«s:"""
+    arg_readers(arg :: AbstractString, [ type = ArgRead ]) do arg::Function
+        ## pre-test setup ##
+        @arg_test arg begin
+            arg :: ArgRead
+            ## test using `arg` ##
+        end
+        ## post-test cleanup ##
+    end
+
+The `arg_readers` function takes a path to be read and a single-argument do
+block, which is invoked once for each test reader type that `arg_read` can
+handle. If the optional `type` argument is given then the do block is only
+invoked for readers that produce arguments of that type.
+
+The `arg` passed to the do block is not the argument value itself, because some
+of test argument types need to be initialized and finalized for each test case.
+Consider an open file handle argument: once you've used it for one test, you
+can't use it again; you need to close it and open the file again for the next
+test. This function `arg` can be converted into an `ArgRead` instance using
+`@arg_test arg begin ... end`.
+"""»
+«k:function» «f:arg_readers»(
+    body::«t:Function»,
+    path::«t:AbstractString»,
+    type::«t:Type» = ArgRead,
+)
+    «k:for» (t, reader) «k:in» ARG_READERS
+        t <: type || «k:continue»
+        body(reader(path))
+    «k:end»
+«k:end»
+
+«s:"""
+    arg_writers([ type = ArgWrite ]) do path::String, arg::Function
+        ## pre-test setup ##
+        @arg_test arg begin
+            arg :: ArgWrite
+            ## test using `arg` ##
+        end
+        ## post-test cleanup ##
+    end
+
+The `arg_writers` function takes a do block, which is invoked once for each test
+writer type that `arg_write` can handle with a temporary (non-existent) `path`
+and `arg` which can be converted into various writable argument types which
+write to `path`. If the optional `type` argument is given then the do block is
+only invoked for writers that produce arguments of that type.
+
+The `arg` passed to the do block is not the argument value itself, because some
+of test argument types need to be initialized and finalized for each test case.
+Consider an open file handle argument: once you've used it for one test, you
+can't use it again; you need to close it and open the file again for the next
+test. This function `arg` can be converted into an `ArgWrite` instance using
+`@arg_test arg begin ... end`.
+
+There is also an `arg_writers` method that takes a path name like `arg_readers`:
+
+    arg_writers(path::AbstractString, [ type = ArgWrite ]) do arg::Function
+        ## pre-test setup ##
+        @arg_test arg begin
+            # here `arg :: ArgWrite`
+            ## test using `arg` ##
+        end
+        ## post-test cleanup ##
+    end
+
+This method is useful if you need to specify `path` instead of using path name
+generated by `tempname()`. Since `path` is passed from outside of `arg_writers`,
+the path is not an argument to the do block in this form.
+"""»
+«k:function» «f:arg_writers»(
+    body::«t:Function»,
+    type::«t:Type» = ArgWrite,
+)
+    «k:for» (t, writer) «k:in» ARG_WRITERS
+        t <: type || «k:continue»
+        «v:path» = tempname()
+        «k:try» body(path, writer(path))
+        «k:finally»
+            rm(path, «:julia-ts-quoted-symbol-face:force»=«c:true»)
+        «k:end»
+    «k:end»
+«k:end»
+
+«k:function» «f:arg_writers»(
+    body::«t:Function»,
+    path::«t:AbstractString»,
+    type::«t:Type» = ArgWrite,
+)
+    «k:for» (t, writer) «k:in» ARG_WRITERS
+        t <: type || «k:continue»
+        body(writer(path))
+    «k:end»
+«k:end»
+
+«s:"""
+    @arg_test arg1 arg2 ... body
+
+The `@arg_test` macro is used to convert `arg` functions provided by
+`arg_readers` and `arg_writers` into actual argument values. When you write
+`@arg_test arg body` it is equivalent to `arg(arg -> body)`.
+"""»
+«k:macro» «f:arg_test»(args...)
+    arg_test(args...)
+«k:end»
+
+«k:function» «f:arg_test»(var::«t:Symbol», args...)
+    «v:var» = esc(var)
+    «v:body» = arg_test(args...)
+    «:julia-ts-quoted-symbol-face::(»«:julia-ts-interpolation-expression-face:$»«D:var»«:julia-ts-quoted-symbol-face:(»«:julia-ts-interpolation-expression-face:$»«D:var»«:julia-ts-quoted-symbol-face: -> »«:julia-ts-interpolation-expression-face:$»«D:body»«:julia-ts-quoted-symbol-face:))»
+«k:end»
+
+«f:arg_test»(ex::«t:Expr») = esc(ex)
+
+«k:end» «x:# module»

--- a/test/ArgTools.jl.faceup
+++ b/test/ArgTools.jl.faceup
@@ -32,7 +32,7 @@ This restriction may be relaxed in the future, which would not break any working
 """»
 
 «k:if» VERSION ≥ «s:v"1.5"»
-    «f:open_nolock»(args...; kws...) = open(args...; kws..., «:julia-ts-quoted-symbol-face:lock»=«c:false»)
+    «f:open_nolock»(args...; kws...) = open(args...; kws..., «:julia-ts-keyword-argument-face:lock»=«c:false»)
 «k:else»
     «f:open_nolock»(args...; kws...) = open(args...; kws...)
 «k:end»
@@ -100,30 +100,30 @@ temporary path generated when `arg` is `nothing`.
 »«:julia-ts-string-interpolation-face:$(»«D:nolock_docstring»«:julia-ts-string-interpolation-face:)»«s:
 """»
 «k:function» «f:arg_write»(f::«t:Function», arg::«t:AbstractString»)
-    «k:try» open_nolock(f, arg, «:julia-ts-quoted-symbol-face:write»=«c:true»)
+    «k:try» open_nolock(f, arg, «:julia-ts-keyword-argument-face:write»=«c:true»)
     «k:catch»
-        rm(arg, «:julia-ts-quoted-symbol-face:force»=«c:true»)
+        rm(arg, «:julia-ts-keyword-argument-face:force»=«c:true»)
         rethrow()
     «k:end»
     «k:return» arg
 «k:end»
 
 «k:function» «f:arg_write»(f::«t:Function», arg::«t:AbstractCmd»)
-    open(f, arg, «:julia-ts-quoted-symbol-face:write»=«c:true»)
+    open(f, arg, «:julia-ts-keyword-argument-face:write»=«c:true»)
     «k:return» arg
 «k:end»
 
 «k:function» «f:arg_write»(f::«t:Function», arg::«t:Nothing»)
     «:julia-ts-macro-face:@static» «k:if» VERSION ≥ «s:v"1.5"»
         «v:file» = tempname()
-        «v:io» = open_nolock(file, «:julia-ts-quoted-symbol-face:write»=«c:true»)
+        «v:io» = open_nolock(file, «:julia-ts-keyword-argument-face:write»=«c:true»)
     «k:else»
         «v:file», «v:io» = mktemp()
     «k:end»
     «k:try» f(io)
     «k:catch»
         close(io)
-        rm(file, «:julia-ts-quoted-symbol-face:force»=«c:true»)
+        rm(file, «:julia-ts-keyword-argument-face:force»=«c:true»)
         rethrow()
     «k:end»
     close(io)
@@ -168,7 +168,7 @@ but was empty, it will be emptied; if it did not exist it will be deleted.
 """»
 «k:function» «f:arg_mkdir»(f::«t:Function», arg::«t:Union»{«t:AbstractString», «t:Nothing»})
     «v:existed» = «c:false»
-    «k:if» arg === «b:nothing»
+    «k:if» arg === «c:nothing»
         «v:arg» = mktempdir()
     «k:else»
         «v:st» = stat(arg)
@@ -188,11 +188,11 @@ but was empty, it will be emptied; if it did not exist it will be deleted.
             «k:for» name «k:in» readdir(arg)
                 «v:path» = joinpath(arg, name)
                 prepare_for_deletion(path)
-                rm(path, «:julia-ts-quoted-symbol-face:force»=«c:true», «:julia-ts-quoted-symbol-face:recursive»=«c:true»)
+                rm(path, «:julia-ts-keyword-argument-face:force»=«c:true», «:julia-ts-keyword-argument-face:recursive»=«c:true»)
             «k:end»
         «k:else»
             prepare_for_deletion(arg)
-            rm(arg, «:julia-ts-quoted-symbol-face:force»=«c:true», «:julia-ts-quoted-symbol-face:recursive»=«c:true»)
+            rm(arg, «:julia-ts-keyword-argument-face:force»=«c:true», «:julia-ts-keyword-argument-face:recursive»=«c:true»)
         «k:end»
         rethrow()
     «k:end»
@@ -213,8 +213,8 @@ but was empty, it will be emptied; if it did not exist it will be deleted.
     String      => path -> f -> f(path)
     Cmd         => path -> f -> f(«s:`tee »«:julia-ts-string-interpolation-face:$»«D:path»«s:`»)
     CmdRedirect => path -> f -> f(pipeline(«s:`cat`», path))
-    IOStream    => path -> f -> open(f, path, «:julia-ts-quoted-symbol-face:write»=«c:true»)
-    Process     => path -> f -> open(f, pipeline(«s:`cat`», path), «:julia-ts-quoted-symbol-face:write»=«c:true»)
+    IOStream    => path -> f -> open(f, path, «:julia-ts-keyword-argument-face:write»=«c:true»)
+    Process     => path -> f -> open(f, pipeline(«s:`cat`», path), «:julia-ts-keyword-argument-face:write»=«c:true»)
 ]
 
 «:julia-ts-macro-face:@assert» all(t <: ArgRead  «k:for» t «k:in» map(first, ARG_READERS))
@@ -300,7 +300,7 @@ the path is not an argument to the do block in this form.
         «v:path» = tempname()
         «k:try» body(path, writer(path))
         «k:finally»
-            rm(path, «:julia-ts-quoted-symbol-face:force»=«c:true»)
+            rm(path, «:julia-ts-keyword-argument-face:force»=«c:true»)
         «k:end»
     «k:end»
 «k:end»

--- a/test/Downloads.jl
+++ b/test/Downloads.jl
@@ -1,0 +1,517 @@
+"""
+The `Downloads` module exports a function [`download`](@ref), which provides cross-platform, multi-protocol,
+in-process download functionality implemented with [libcurl](https://curl.haxx.se/libcurl/).   It is used
+for the `Base.download` function in Julia 1.6 or later.
+
+More generally, the module exports functions and types that provide lower-level control and diagnostic information
+for file downloading:
+- [`download`](@ref) — download a file from a URL, erroring if it can't be downloaded
+- [`request`](@ref) — request a URL, returning a `Response` object indicating success
+- [`Response`](@ref) — a type capturing the status and other metadata about a request
+- [`RequestError`](@ref) — an error type thrown by `download` and `request` on error
+- [`Downloader`](@ref) — an object encapsulating shared resources for downloading
+"""
+module Downloads
+
+using Base.Experimental: @sync
+using NetworkOptions
+using ArgTools
+
+include("Curl/Curl.jl")
+using .Curl
+
+export download, request, Downloader, Response, RequestError, default_downloader!
+
+## public API types ##
+
+"""
+    Downloader(; [ grace::Real = 30 ])
+
+`Downloader` objects are used to perform individual `download` operations.
+Connections, name lookups and other resources are shared within a `Downloader`.
+These connections and resources are cleaned up after a configurable grace period
+(default: 30 seconds) since anything was downloaded with it, or when it is
+garbage collected, whichever comes first. If the grace period is set to zero,
+all resources will be cleaned up immediately as soon as there are no more
+ongoing downloads in progress. If the grace period is set to `Inf` then
+resources are not cleaned up until `Downloader` is garbage collected.
+"""
+mutable struct Downloader
+    multi::Multi
+    ca_roots::Union{String, Nothing}
+    easy_hook::Union{Function, Nothing}
+
+    Downloader(multi::Multi) = new(multi, get_ca_roots(), EASY_HOOK[])
+end
+Downloader(; grace::Real=30) = Downloader(Multi(grace_ms(grace)))
+
+function grace_ms(grace::Real)
+    grace < 0 && throw(ArgumentError("grace period cannot be negative: $grace"))
+    grace <= typemax(UInt64) ÷ 1000 ? round(UInt64, 1000*grace) : typemax(UInt64)
+end
+
+function easy_hook(downloader::Downloader, easy::Easy, info::NamedTuple)
+    hook = downloader.easy_hook
+    hook !== nothing && Base.invokelatest(hook, easy, info)
+end
+
+get_ca_roots() = Curl.SYSTEM_SSL ? ca_roots() : ca_roots_path()
+
+function set_ca_roots(downloader::Downloader, easy::Easy)
+    ca_roots = downloader.ca_roots
+    ca_roots !== nothing && set_ca_roots_path(easy, ca_roots)
+end
+
+const DOWNLOAD_LOCK = ReentrantLock()
+const DOWNLOADER = Ref{Union{Downloader, Nothing}}(nothing)
+
+"""
+`EASY_HOOK` is a modifable global hook to used as the default `easy_hook` on
+new `Downloader` objects. This supplies a mechanism to set options for the
+`Downloader` via `Curl.setopt`
+
+It is expected to be function taking two arguments: an `Easy` struct and an
+`info` NamedTuple with names `url`, `method` and `headers`.
+"""
+const EASY_HOOK = Ref{Union{Function, Nothing}}(nothing)
+
+"""
+    struct Response
+        proto   :: String
+        url     :: String
+        status  :: Int
+        message :: String
+        headers :: Vector{Pair{String,String}}
+    end
+
+`Response` is a type capturing the properties of a successful response to a
+request as an object. It has the following fields:
+
+- `proto`: the protocol that was used to get the response
+- `url`: the URL that was ultimately requested after following redirects
+- `status`: the status code of the response, indicating success, failure, etc.
+- `message`: a textual message describing the nature of the response
+- `headers`: any headers that were returned with the response
+
+The meaning and availability of some of these responses depends on the protocol
+used for the request. For many protocols, including HTTP/S and S/FTP, a 2xx
+status code indicates a successful response. For responses in protocols that do
+not support headers, the headers vector will be empty. HTTP/2 does not include a
+status message, only a status code, so the message will be empty.
+"""
+struct Response
+    proto   :: Union{String, Nothing}
+    url     :: String # redirected URL
+    status  :: Int
+    message :: String
+    headers :: Vector{Pair{String,String}}
+end
+
+Curl.status_ok(response::Response) = status_ok(response.proto, response.status)
+
+"""
+    struct RequestError <: ErrorException
+        url      :: String
+        code     :: Int
+        message  :: String
+        response :: Response
+    end
+
+`RequestError` is a type capturing the properties of a failed response to a
+request as an exception object:
+
+- `url`: the original URL that was requested without any redirects
+- `code`: the libcurl error code; `0` if a protocol-only error occurred
+- `message`: the libcurl error message indicating what went wrong
+- `response`: response object capturing what response info is available
+
+The same `RequestError` type is thrown by `download` if the request was
+successful but there was a protocol-level error indicated by a status code that
+is not in the 2xx range, in which case `code` will be zero and the `message`
+field will be the empty string. The `request` API only throws a `RequestError`
+if the libcurl error `code` is non-zero, in which case the included `response`
+object is likely to have a `status` of zero and an empty message. There are,
+however, situations where a curl-level error is thrown due to a protocol error,
+in which case both the inner and outer code and message may be of interest.
+"""
+struct RequestError <: Exception
+    url      :: String # original URL
+    code     :: Int
+    message  :: String
+    response :: Response
+end
+
+function Base.showerror(io::IO, err::RequestError)
+    print(io, "RequestError: $(error_message(err)) while requesting $(err.url)")
+end
+
+function error_message(err::RequestError)
+    errstr = err.message
+    status = err.response.status
+    message = err.response.message
+    status_re = Regex(status == 0 ? "" : "\\b$status\\b")
+
+    err.code == Curl.CURLE_OK &&
+        return isempty(message) ? "Error status $status" :
+            contains(message, status_re) ? message :
+                "$message (status $status)"
+
+    isempty(message) && !isempty(errstr) &&
+        return status == 0 ? errstr : "$errstr (status $status)"
+
+    isempty(message) && (message = "Status $status")
+    isempty(errstr)  && (errstr = "curl error $(err.code)")
+
+    !contains(message, status_re) && !contains(errstr, status_re) &&
+        (errstr = "status $status; $errstr")
+
+    return "$message ($errstr)"
+end
+
+## download API ##
+
+"""
+    download(url, [ output = tempname() ];
+        [ method = "GET", ]
+        [ headers = <none>, ]
+        [ timeout = <none>, ]
+        [ progress = <none>, ]
+        [ verbose = false, ]
+        [ debug = <none>, ]
+        [ downloader = <default>, ]
+    ) -> output
+
+        url        :: AbstractString
+        output     :: Union{AbstractString, AbstractCmd, IO}
+        method     :: AbstractString
+        headers    :: Union{AbstractVector, AbstractDict}
+        timeout    :: Real
+        progress   :: (total::Integer, now::Integer) --> Any
+        verbose    :: Bool
+        debug      :: (type, message) --> Any
+        downloader :: Downloader
+
+Download a file from the given url, saving it to `output` or if not specified, a
+temporary path. The `output` can also be an `IO` handle, in which case the body
+of the response is streamed to that handle and the handle is returned. If
+`output` is a command, the command is run and output is sent to it on stdin.
+
+If the `downloader` keyword argument is provided, it must be a `Downloader`
+object. Resources and connections will be shared between downloads performed by
+the same `Downloader` and cleaned up automatically when the object is garbage
+collected or there have been no downloads performed with it for a grace period.
+See `Downloader` for more info about configuration and usage.
+
+If the `headers` keyword argument is provided, it must be a vector or dictionary
+whose elements are all pairs of strings. These pairs are passed as headers when
+downloading URLs with protocols that supports them, such as HTTP/S.
+
+The `timeout` keyword argument specifies a timeout for the download to complete in
+seconds, with a resolution of milliseconds. By default no timeout is set, but this
+can also be explicitly requested by passing a timeout value of `Inf`. Separately,
+if 20 seconds elapse without receiving any data, the download will timeout. See
+extended help for how to disable this timeout.
+
+If the `progress` keyword argument is provided, it must be a callback function
+which will be called whenever there are updates about the size and status of the
+ongoing download. The callback must take two integer arguments: `total` and
+`now` which are the total size of the download in bytes, and the number of bytes
+which have been downloaded so far. Note that `total` starts out as zero and
+remains zero until the server gives an indication of the total size of the
+download (e.g. with a `Content-Length` header), which may never happen. So a
+well-behaved progress callback should handle a total size of zero gracefully.
+
+If the `verbose` option is set to true, `libcurl`, which is used to implement
+the download functionality will print debugging information to `stderr`. If the
+`debug` option is set to a function accepting two `String` arguments, then the
+verbose option is ignored and instead the data that would have been printed to
+`stderr` is passed to the `debug` callback with `type` and `message` arguments.
+The `type` argument indicates what kind of event has occurred, and is one of:
+`TEXT`, `HEADER IN`, `HEADER OUT`, `DATA IN`, `DATA OUT`, `SSL DATA IN` or `SSL
+DATA OUT`. The `message` argument is the description of the debug event.
+
+## Extended Help
+
+For further customization, use a [`Downloader`](@ref) and
+[`easy_hook`s](https://github.com/JuliaLang/Downloads.jl#mutual-tls-using-downloads).
+For example, to disable the 20 second timeout when no data is received, you may
+use the following:
+
+```jl
+downloader = Downloads.Downloader()
+downloader.easy_hook = (easy, info) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, 0)
+
+Downloads.download("https://httpbingo.julialang.org/delay/30"; downloader)
+```
+"""
+function download(
+    url        :: AbstractString,
+    output     :: Union{ArgWrite, Nothing} = nothing;
+    method     :: Union{AbstractString, Nothing} = nothing,
+    headers    :: Union{AbstractVector, AbstractDict} = Pair{String,String}[],
+    timeout    :: Real = Inf,
+    progress   :: Union{Function, Nothing} = nothing,
+    verbose    :: Bool = false,
+    debug      :: Union{Function, Nothing} = nothing,
+    downloader :: Union{Downloader, Nothing} = nothing,
+) :: ArgWrite
+    arg_write(output) do output
+        response = request(
+            url,
+            output = output,
+            method = method,
+            headers = headers,
+            timeout = timeout,
+            progress = progress,
+            verbose = verbose,
+            debug = debug,
+            downloader = downloader,
+        )::Response
+        status_ok(response) && return output
+        throw(RequestError(url, Curl.CURLE_OK, "", response))
+    end
+end
+
+## request API ##
+
+"""
+    request(url;
+        [ input = <none>, ]
+        [ output = <none>, ]
+        [ method = input ? "PUT" : output ? "GET" : "HEAD", ]
+        [ headers = <none>, ]
+        [ timeout = <none>, ]
+        [ progress = <none>, ]
+        [ verbose = false, ]
+        [ debug = <none>, ]
+        [ throw = true, ]
+        [ downloader = <default>, ]
+        [ interrupt = <none>, ]
+    ) -> Union{Response, RequestError}
+
+        url        :: AbstractString
+        input      :: Union{AbstractString, AbstractCmd, IO}
+        output     :: Union{AbstractString, AbstractCmd, IO}
+        method     :: AbstractString
+        headers    :: Union{AbstractVector, AbstractDict}
+        timeout    :: Real
+        progress   :: (dl_total, dl_now, ul_total, ul_now) --> Any
+        verbose    :: Bool
+        debug      :: (type, message) --> Any
+        throw      :: Bool
+        downloader :: Downloader
+        interrupt  :: Base.Event
+
+Make a request to the given url, returning a `Response` object capturing the
+status, headers and other information about the response. The body of the
+response is written to `output` if specified and discarded otherwise. For HTTP/S
+requests, if an `input` stream is given, a `PUT` request is made; otherwise if
+an `output` stream is given, a `GET` request is made; if neither is given a
+`HEAD` request is made. For other protocols, appropriate default methods are
+used based on what combination of input and output are requested. The following
+options differ from the `download` function:
+
+- `input` allows providing a request body; if provided default to `PUT` request
+- `progress` is a callback taking four integers for upload and download progress
+- `throw` controls whether to throw or return a `RequestError` on request error
+
+Note that unlike `download` which throws an error if the requested URL could not
+be downloaded (indicated by non-2xx status code), `request` returns a `Response`
+object no matter what the status code of the response is. If there is an error
+with getting a response at all, then a `RequestError` is thrown or returned.
+
+If the `interrupt` keyword argument is provided, it must be a `Base.Event` object.
+If the event is triggered while the request is in progress, the request will be
+cancelled and an error will be thrown. This can be used to interrupt a long
+running request, for example if the user wants to cancel a download.
+"""
+function request(
+    url        :: AbstractString;
+    input      :: Union{ArgRead, Nothing} = nothing,
+    output     :: Union{ArgWrite, Nothing} = nothing,
+    method     :: Union{AbstractString, Nothing} = nothing,
+    headers    :: Union{AbstractVector, AbstractDict} = Pair{String,String}[],
+    timeout    :: Real = Inf,
+    progress   :: Union{Function, Nothing} = nothing,
+    verbose    :: Bool = false,
+    debug      :: Union{Function, Nothing} = nothing,
+    throw      :: Bool = true,
+    downloader :: Union{Downloader, Nothing} = nothing,
+    interrupt  :: Union{Nothing, Base.Event} = nothing,
+) :: Union{Response, RequestError}
+    if downloader === nothing
+        lock(DOWNLOAD_LOCK) do
+            downloader = DOWNLOADER[]
+            if downloader === nothing
+                downloader = DOWNLOADER[] = Downloader()
+            end
+        end
+    end
+    local response
+    have_input = input !== nothing
+    have_output = output !== nothing
+    input = something(input, devnull)
+    output = something(output, devnull)
+    input_size = arg_read_size(input)
+    if input_size === nothing
+        # take input_size from content-length header if one is supplied
+        input_size = content_length(headers)
+    end
+    progress = p_func(progress, input, output)
+    arg_read(input) do input
+        arg_write(output) do output
+            with_handle(Easy()) do easy
+                # setup the request
+                set_url(easy, url)
+                set_timeout(easy, timeout)
+                set_verbose(easy, verbose)
+                set_debug(easy, debug)
+                add_headers(easy, headers)
+
+                # libcurl does not set the default header reliably so set it
+                # explicitly unless user has specified it, xref
+                # https://github.com/JuliaLang/Pkg.jl/pull/2357
+                if !any(kv -> lowercase(kv[1]) == "user-agent", headers)
+                    Curl.add_header(easy, "User-Agent", Curl.USER_AGENT)
+                end
+
+                if have_input
+                    enable_upload(easy)
+                    if input_size !== nothing
+                        set_upload_size(easy, input_size)
+                    end
+                    if applicable(seek, input, 0)
+                        set_seeker(easy) do offset
+                            seek(input, Int(offset))
+                        end
+                    end
+                else
+                    set_body(easy, have_output && method != "HEAD")
+                end
+                method !== nothing && set_method(easy, method)
+                progress !== nothing && enable_progress(easy)
+                set_ca_roots(downloader, easy)
+                info = (url = url, method = method, headers = headers)
+                easy_hook(downloader, easy, info)
+
+                # do the request
+                add_handle(downloader.multi, easy)
+                interrupted = Threads.Atomic{Bool}(false)
+                if interrupt !== nothing
+                    interrupt_task = @async begin
+                        # wait for the interrupt event
+                        wait(interrupt)
+                        # cancel the request
+                        remove_handle(downloader.multi, easy)
+                        close(easy.output)
+                        close(easy.progress)
+                        interrupted[] = true
+                        close(input)
+                        notify(easy.ready)
+                    end
+                else
+                    interrupt_task = nothing
+                end
+                try # ensure handle is removed
+                    @sync begin
+                        @async for buf in easy.output
+                            write(output, buf)
+                        end
+                        if progress !== nothing
+                            @async for prog in easy.progress
+                                progress(prog...)
+                            end
+                        end
+                        if have_input
+                            @async upload_data(easy, input)
+                        end
+                    end
+                finally
+                    if !(interrupted[])
+                        if interrupt_task !== nothing
+                            # trigger interrupt
+                            notify(interrupt)
+                            wait(interrupt_task)
+                        else
+                            remove_handle(downloader.multi, easy)
+                        end
+                    end
+                end
+
+                # return the response or throw an error
+                response = Response(get_response_info(easy)...)
+                easy.code == Curl.CURLE_OK && return response
+                message = get_curl_errstr(easy)
+                if easy.code == typemax(Curl.CURLcode)
+                    # uninitialized code, likely a protocol error
+                    code = Int(0)
+                else
+                    code = Int(easy.code)
+                end
+                response = RequestError(url, code, message, response)
+                throw && Base.throw(response)
+            end
+        end
+    end
+    return response
+end
+
+## helper functions ##
+
+function p_func(progress::Function, input::ArgRead, output::ArgWrite)
+    hasmethod(progress, NTuple{4,Int}) && return progress
+    hasmethod(progress, NTuple{2,Int}) ||
+        throw(ArgumentError("invalid progress callback"))
+
+    input === devnull && output !== devnull &&
+        return (total, now, _, _) -> progress(total, now)
+    input !== devnull && output === devnull &&
+        return (_, _, total, now) -> progress(total, now)
+
+    (dl_total, dl_now, ul_total, ul_now) ->
+        progress(dl_total + ul_total, dl_now + ul_now)
+end
+p_func(progress::Nothing, input::ArgRead, output::ArgWrite) = nothing
+
+arg_read_size(path::AbstractString) = filesize(path)
+arg_read_size(io::Base.GenericIOBuffer) = bytesavailable(io)
+arg_read_size(::Base.DevNull) = 0
+arg_read_size(::Any) = nothing
+
+function content_length(headers::Union{AbstractVector, AbstractDict})
+    for (key, value) in headers
+        if lowercase(key) == "content-length" && isa(value, AbstractString)
+            return tryparse(Int, value)
+        end
+    end
+    return nothing
+end
+
+"""
+    default_downloader!(
+        downloader = <none>
+    )
+
+        downloader :: Downloader
+
+Set the default `Downloader`. If no argument is provided, resets the default downloader so that a fresh one is created the next time the default downloader is needed.
+"""
+function default_downloader!(
+    downloader :: Union{Downloader, Nothing} = nothing
+)
+    lock(DOWNLOAD_LOCK) do
+        DOWNLOADER[] = downloader
+    end
+end
+
+# Precompile
+let
+    Curl.__init__()
+    d = Downloader()
+    f = mktemp()[1]
+    download("file://" * f; downloader=d)
+    precompile(Tuple{typeof(Downloads.download), String, String})
+    precompile(Tuple{typeof(Downloads.Curl.status_2xx_ok), Int64})
+end
+
+end # module

--- a/test/Downloads.jl.faceup
+++ b/test/Downloads.jl.faceup
@@ -41,7 +41,7 @@ resources are not cleaned up until `Downloader` is garbage collected.
     ca_roots::«t:Union»{«t:String», «t:Nothing»}
     easy_hook::«t:Union»{«t:Function», «t:Nothing»}
 
-    «f:Downloader»(multi::«t:Multi») = «k:new»(multi, get_ca_roots(), EASY_HOOK[])
+    «f:Downloader»(multi::«t:Multi») = new(multi, get_ca_roots(), EASY_HOOK[])
 «k:end»
 «f:Downloader»(; grace::«t:Real»=«c:30») = Downloader(Multi(grace_ms(grace)))
 
@@ -52,18 +52,18 @@ resources are not cleaned up until `Downloader` is garbage collected.
 
 «k:function» «f:easy_hook»(downloader::«t:Downloader», easy::«t:Easy», info::«t:NamedTuple»)
     «v:hook» = downloader.easy_hook
-    hook !== «b:nothing» && Base.invokelatest(hook, easy, info)
+    hook !== «c:nothing» && Base.invokelatest(hook, easy, info)
 «k:end»
 
 «f:get_ca_roots»() = Curl.SYSTEM_SSL ? ca_roots() : ca_roots_path()
 
 «k:function» «f:set_ca_roots»(downloader::«t:Downloader», easy::«t:Easy»)
     «v:ca_roots» = downloader.ca_roots
-    ca_roots !== «b:nothing» && set_ca_roots_path(easy, ca_roots)
+    ca_roots !== «c:nothing» && set_ca_roots_path(easy, ca_roots)
 «k:end»
 
 «k:const» «v:DOWNLOAD_LOCK» = ReentrantLock()
-«k:const» «v:DOWNLOADER» = «t:Ref»{«t:Union»{«t:Downloader», «t:Nothing»}}(«b:nothing»)
+«k:const» «v:DOWNLOADER» = «t:Ref»{«t:Union»{«t:Downloader», «t:Nothing»}}(«c:nothing»)
 
 «s:"""
 `EASY_HOOK` is a modifable global hook to used as the default `easy_hook` on
@@ -73,7 +73,7 @@ new `Downloader` objects. This supplies a mechanism to set options for the
 It is expected to be function taking two arguments: an `Easy` struct and an
 `info` NamedTuple with names `url`, `method` and `headers`.
 """»
-«k:const» «v:EASY_HOOK» = «t:Ref»{«t:Union»{«t:Function», «t:Nothing»}}(«b:nothing»)
+«k:const» «v:EASY_HOOK» = «t:Ref»{«t:Union»{«t:Function», «t:Nothing»}}(«c:nothing»)
 
 «s:"""
     struct Response
@@ -246,26 +246,26 @@ Downloads.download("https://httpbingo.julialang.org/delay/30"; downloader)
 """»
 «k:function» «f:download»(
     url        :: «t:AbstractString»,
-    output     :: «t:Union»{«t:ArgWrite», «t:Nothing»} = «b:nothing»;
-    method     :: «t:Union»{«t:AbstractString», «t:Nothing»} = «b:nothing»,
+    output     :: «t:Union»{«t:ArgWrite», «t:Nothing»} = «c:nothing»;
+    method     :: «t:Union»{«t:AbstractString», «t:Nothing»} = «c:nothing»,
     headers    :: «t:Union»{«t:AbstractVector», «t:AbstractDict»} = «t:Pair»{«t:String»,«t:String»}[],
-    timeout    :: «t:Real» = «b:Inf»,
-    progress   :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
+    timeout    :: «t:Real» = «c:Inf»,
+    progress   :: «t:Union»{«t:Function», «t:Nothing»} = «c:nothing»,
     verbose    :: «t:Bool» = «c:false»,
-    debug      :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
-    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «b:nothing»,
+    debug      :: «t:Union»{«t:Function», «t:Nothing»} = «c:nothing»,
+    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «c:nothing»,
 ) :: «t:ArgWrite»
     arg_write(output) «k:do» output
         «v:response» = request(
             url,
-            «:julia-ts-quoted-symbol-face:output» = output,
-            «:julia-ts-quoted-symbol-face:method» = method,
-            «:julia-ts-quoted-symbol-face:headers» = headers,
-            «:julia-ts-quoted-symbol-face:timeout» = timeout,
-            «:julia-ts-quoted-symbol-face:progress» = progress,
-            «:julia-ts-quoted-symbol-face:verbose» = verbose,
-            «:julia-ts-quoted-symbol-face:debug» = debug,
-            «:julia-ts-quoted-symbol-face:downloader» = downloader,
+            «:julia-ts-keyword-argument-face:output» = output,
+            «:julia-ts-keyword-argument-face:method» = method,
+            «:julia-ts-keyword-argument-face:headers» = headers,
+            «:julia-ts-keyword-argument-face:timeout» = timeout,
+            «:julia-ts-keyword-argument-face:progress» = progress,
+            «:julia-ts-keyword-argument-face:verbose» = verbose,
+            «:julia-ts-keyword-argument-face:debug» = debug,
+            «:julia-ts-keyword-argument-face:downloader» = downloader,
         )::«t:Response»
         status_ok(response) && «k:return» output
         throw(RequestError(url, Curl.CURLE_OK, «s:""», response))
@@ -327,33 +327,33 @@ running request, for example if the user wants to cancel a download.
 """»
 «k:function» «f:request»(
     url        :: «t:AbstractString»;
-    input      :: «t:Union»{«t:ArgRead», «t:Nothing»} = «b:nothing»,
-    output     :: «t:Union»{«t:ArgWrite», «t:Nothing»} = «b:nothing»,
-    method     :: «t:Union»{«t:AbstractString», «t:Nothing»} = «b:nothing»,
+    input      :: «t:Union»{«t:ArgRead», «t:Nothing»} = «c:nothing»,
+    output     :: «t:Union»{«t:ArgWrite», «t:Nothing»} = «c:nothing»,
+    method     :: «t:Union»{«t:AbstractString», «t:Nothing»} = «c:nothing»,
     headers    :: «t:Union»{«t:AbstractVector», «t:AbstractDict»} = «t:Pair»{«t:String»,«t:String»}[],
-    timeout    :: «t:Real» = «b:Inf»,
-    progress   :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
+    timeout    :: «t:Real» = «c:Inf»,
+    progress   :: «t:Union»{«t:Function», «t:Nothing»} = «c:nothing»,
     verbose    :: «t:Bool» = «c:false»,
-    debug      :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
+    debug      :: «t:Union»{«t:Function», «t:Nothing»} = «c:nothing»,
     throw      :: «t:Bool» = «c:true»,
-    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «b:nothing»,
-    interrupt  :: «t:Union»{«t:Nothing», Base.Event} = «b:nothing»,
+    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «c:nothing»,
+    interrupt  :: «t:Union»{«t:Nothing», Base.Event} = «c:nothing»,
 ) :: «t:Union»{«t:Response», «t:RequestError»}
-    «k:if» downloader === «b:nothing»
+    «k:if» downloader === «c:nothing»
         lock(DOWNLOAD_LOCK) «k:do»
             «v:downloader» = DOWNLOADER[]
-            «k:if» downloader === «b:nothing»
+            «k:if» downloader === «c:nothing»
                 «v:downloader» = DOWNLOADER[] = Downloader()
             «k:end»
         «k:end»
     «k:end»
     «k:local» «v:response»
-    «v:have_input» = input !== «b:nothing»
-    «v:have_output» = output !== «b:nothing»
+    «v:have_input» = input !== «c:nothing»
+    «v:have_output» = output !== «c:nothing»
     «v:input» = something(input, devnull)
     «v:output» = something(output, devnull)
     «v:input_size» = arg_read_size(input)
-    «k:if» input_size === «b:nothing»
+    «k:if» input_size === «c:nothing»
         «x:# take input_size from content-length header if one is supplied»
         «v:input_size» = content_length(headers)
     «k:end»
@@ -377,7 +377,7 @@ running request, for example if the user wants to cancel a download.
 
                 «k:if» have_input
                     enable_upload(easy)
-                    «k:if» input_size !== «b:nothing»
+                    «k:if» input_size !== «c:nothing»
                         set_upload_size(easy, input_size)
                     «k:end»
                     «k:if» applicable(seek, input, «c:0»)
@@ -388,8 +388,8 @@ running request, for example if the user wants to cancel a download.
                 «k:else»
                     set_body(easy, have_output && method != «s:"HEAD"»)
                 «k:end»
-                method !== «b:nothing» && set_method(easy, method)
-                progress !== «b:nothing» && enable_progress(easy)
+                method !== «c:nothing» && set_method(easy, method)
+                progress !== «c:nothing» && enable_progress(easy)
                 set_ca_roots(downloader, easy)
                 «v:info» = (url = url, method = method, headers = headers)
                 easy_hook(downloader, easy, info)
@@ -397,7 +397,7 @@ running request, for example if the user wants to cancel a download.
                 «x:# do the request»
                 add_handle(downloader.multi, easy)
                 «v:interrupted» = Threads.Atomic{«t:Bool»}(«c:false»)
-                «k:if» interrupt !== «b:nothing»
+                «k:if» interrupt !== «c:nothing»
                     «v:interrupt_task» = «:julia-ts-macro-face:@async» «k:begin»
                         «x:# wait for the interrupt event»
                         wait(interrupt)
@@ -410,14 +410,14 @@ running request, for example if the user wants to cancel a download.
                         notify(easy.ready)
                     «k:end»
                 «k:else»
-                    «v:interrupt_task» = «b:nothing»
+                    «v:interrupt_task» = «c:nothing»
                 «k:end»
                 «k:try» «x:# ensure handle is removed»
                     «:julia-ts-macro-face:@sync» «k:begin»
                         «:julia-ts-macro-face:@async» «k:for» buf «k:in» easy.output
                             write(output, buf)
                         «k:end»
-                        «k:if» progress !== «b:nothing»
+                        «k:if» progress !== «c:nothing»
                             «:julia-ts-macro-face:@async» «k:for» prog «k:in» easy.progress
                                 progress(prog...)
                             «k:end»
@@ -428,7 +428,7 @@ running request, for example if the user wants to cancel a download.
                     «k:end»
                 «k:finally»
                     «k:if» !(interrupted[])
-                        «k:if» interrupt_task !== «b:nothing»
+                        «k:if» interrupt_task !== «c:nothing»
                             «x:# trigger interrupt»
                             notify(interrupt)
                             wait(interrupt_task)
@@ -471,12 +471,12 @@ running request, for example if the user wants to cancel a download.
     (dl_total, dl_now, ul_total, ul_now) ->
         progress(dl_total + ul_total, dl_now + ul_now)
 «k:end»
-«f:p_func»(progress::«t:Nothing», input::«t:ArgRead», output::«t:ArgWrite») = «b:nothing»
+«f:p_func»(progress::«t:Nothing», input::«t:ArgRead», output::«t:ArgWrite») = «c:nothing»
 
 «f:arg_read_size»(path::«t:AbstractString») = filesize(path)
 «f:arg_read_size»(io::Base.«t:GenericIOBuffer») = bytesavailable(io)
 «f:arg_read_size»(::«t:Base.DevNull») = «c:0»
-«f:arg_read_size»(::«t:Any») = «b:nothing»
+«f:arg_read_size»(::«t:Any») = «c:nothing»
 
 «k:function» «f:content_length»(headers::«t:Union»{«t:AbstractVector», «t:AbstractDict»})
     «k:for» (key, value) «k:in» headers
@@ -484,7 +484,7 @@ running request, for example if the user wants to cancel a download.
             «k:return» tryparse(Int, value)
         «k:end»
     «k:end»
-    «k:return» «b:nothing»
+    «k:return» «c:nothing»
 «k:end»
 
 «s:"""
@@ -497,7 +497,7 @@ running request, for example if the user wants to cancel a download.
 Set the default `Downloader`. If no argument is provided, resets the default downloader so that a fresh one is created the next time the default downloader is needed.
 """»
 «k:function» «f:default_downloader!»(
-    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «b:nothing»
+    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «c:nothing»
 )
     lock(DOWNLOAD_LOCK) «k:do»
         DOWNLOADER[] = downloader
@@ -509,7 +509,7 @@ Set the default `Downloader`. If no argument is provided, resets the default dow
     Curl.__init__()
     «v:d» = Downloader()
     «v:f» = mktemp()[«c:1»]
-    download(«s:"file://"» * f; «:julia-ts-quoted-symbol-face:downloader»=d)
+    download(«s:"file://"» * f; «:julia-ts-keyword-argument-face:downloader»=d)
     precompile(«t:Tuple»{typeof(Downloads.download), «t:String», «t:String»})
     precompile(«t:Tuple»{typeof(Downloads.Curl.status_2xx_ok), «t:Int64»})
 «k:end»

--- a/test/Downloads.jl.faceup
+++ b/test/Downloads.jl.faceup
@@ -38,10 +38,10 @@ resources are not cleaned up until `Downloader` is garbage collected.
 """»
 «k:mutable» «k:struct» «t:Downloader»
     multi::«t:Multi»
-    ca_roots::«t:Union{String, Nothing}»
-    easy_hook::«t:Union{Function, Nothing}»
+    ca_roots::«t:Union»{«t:String», «t:Nothing»}
+    easy_hook::«t:Union»{«t:Function», «t:Nothing»}
 
-    «f:Downloader»(multi::«t:Multi») = new(multi, get_ca_roots(), EASY_HOOK[])
+    «f:Downloader»(multi::«t:Multi») = «k:new»(multi, get_ca_roots(), EASY_HOOK[])
 «k:end»
 «f:Downloader»(; grace::«t:Real»=«c:30») = Downloader(Multi(grace_ms(grace)))
 
@@ -63,7 +63,7 @@ resources are not cleaned up until `Downloader` is garbage collected.
 «k:end»
 
 «k:const» «v:DOWNLOAD_LOCK» = ReentrantLock()
-«k:const» «v:DOWNLOADER» = Ref{Union{Downloader, Nothing}}(«b:nothing»)
+«k:const» «v:DOWNLOADER» = «t:Ref»{«t:Union»{«t:Downloader», «t:Nothing»}}(«b:nothing»)
 
 «s:"""
 `EASY_HOOK` is a modifable global hook to used as the default `easy_hook` on
@@ -73,7 +73,7 @@ new `Downloader` objects. This supplies a mechanism to set options for the
 It is expected to be function taking two arguments: an `Easy` struct and an
 `info` NamedTuple with names `url`, `method` and `headers`.
 """»
-«k:const» «v:EASY_HOOK» = Ref{Union{Function, Nothing}}(«b:nothing»)
+«k:const» «v:EASY_HOOK» = «t:Ref»{«t:Union»{«t:Function», «t:Nothing»}}(«b:nothing»)
 
 «s:"""
     struct Response
@@ -100,11 +100,11 @@ not support headers, the headers vector will be empty. HTTP/2 does not include a
 status message, only a status code, so the message will be empty.
 """»
 «k:struct» «t:Response»
-    proto   :: «t:Union{String, Nothing}»
+    proto   :: «t:Union»{«t:String», «t:Nothing»}
     url     :: «t:String» «x:# redirected URL»
     status  :: «t:Int»
     message :: «t:String»
-    headers :: «t:Vector{Pair{String,String}}»
+    headers :: «t:Vector»{«t:Pair»{«t:String»,«t:String»}}
 «k:end»
 
 Curl.«f:status_ok»(response::«t:Response») = status_ok(response.proto, response.status)
@@ -246,14 +246,14 @@ Downloads.download("https://httpbingo.julialang.org/delay/30"; downloader)
 """»
 «k:function» «f:download»(
     url        :: «t:AbstractString»,
-    output     :: «t:Union{ArgWrite, Nothing}» = «b:nothing»;
-    method     :: «t:Union{AbstractString, Nothing}» = «b:nothing»,
-    headers    :: «t:Union{AbstractVector, AbstractDict}» = Pair{String,String}[],
+    output     :: «t:Union»{«t:ArgWrite», «t:Nothing»} = «b:nothing»;
+    method     :: «t:Union»{«t:AbstractString», «t:Nothing»} = «b:nothing»,
+    headers    :: «t:Union»{«t:AbstractVector», «t:AbstractDict»} = «t:Pair»{«t:String»,«t:String»}[],
     timeout    :: «t:Real» = «b:Inf»,
-    progress   :: «t:Union{Function, Nothing}» = «b:nothing»,
+    progress   :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
     verbose    :: «t:Bool» = «c:false»,
-    debug      :: «t:Union{Function, Nothing}» = «b:nothing»,
-    downloader :: «t:Union{Downloader, Nothing}» = «b:nothing»,
+    debug      :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
+    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «b:nothing»,
 ) :: «t:ArgWrite»
     arg_write(output) «k:do» output
         «v:response» = request(
@@ -327,18 +327,18 @@ running request, for example if the user wants to cancel a download.
 """»
 «k:function» «f:request»(
     url        :: «t:AbstractString»;
-    input      :: «t:Union{ArgRead, Nothing}» = «b:nothing»,
-    output     :: «t:Union{ArgWrite, Nothing}» = «b:nothing»,
-    method     :: «t:Union{AbstractString, Nothing}» = «b:nothing»,
-    headers    :: «t:Union{AbstractVector, AbstractDict}» = Pair{String,String}[],
+    input      :: «t:Union»{«t:ArgRead», «t:Nothing»} = «b:nothing»,
+    output     :: «t:Union»{«t:ArgWrite», «t:Nothing»} = «b:nothing»,
+    method     :: «t:Union»{«t:AbstractString», «t:Nothing»} = «b:nothing»,
+    headers    :: «t:Union»{«t:AbstractVector», «t:AbstractDict»} = «t:Pair»{«t:String»,«t:String»}[],
     timeout    :: «t:Real» = «b:Inf»,
-    progress   :: «t:Union{Function, Nothing}» = «b:nothing»,
+    progress   :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
     verbose    :: «t:Bool» = «c:false»,
-    debug      :: «t:Union{Function, Nothing}» = «b:nothing»,
+    debug      :: «t:Union»{«t:Function», «t:Nothing»} = «b:nothing»,
     throw      :: «t:Bool» = «c:true»,
-    downloader :: «t:Union{Downloader, Nothing}» = «b:nothing»,
-    interrupt  :: «t:Union{Nothing, Base.Event}» = «b:nothing»,
-) :: «t:Union{Response, RequestError}»
+    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «b:nothing»,
+    interrupt  :: «t:Union»{«t:Nothing», Base.Event} = «b:nothing»,
+) :: «t:Union»{«t:Response», «t:RequestError»}
     «k:if» downloader === «b:nothing»
         lock(DOWNLOAD_LOCK) «k:do»
             «v:downloader» = DOWNLOADER[]
@@ -396,7 +396,7 @@ running request, for example if the user wants to cancel a download.
 
                 «x:# do the request»
                 add_handle(downloader.multi, easy)
-                «v:interrupted» = Threads.Atomic{Bool}(«c:false»)
+                «v:interrupted» = Threads.Atomic{«t:Bool»}(«c:false»)
                 «k:if» interrupt !== «b:nothing»
                     «v:interrupt_task» = «:julia-ts-macro-face:@async» «k:begin»
                         «x:# wait for the interrupt event»
@@ -459,8 +459,8 @@ running request, for example if the user wants to cancel a download.
 «x:## helper functions ##»
 
 «k:function» «f:p_func»(progress::«t:Function», input::«t:ArgRead», output::«t:ArgWrite»)
-    hasmethod(progress, NTuple{«c:4»,Int}) && «k:return» progress
-    hasmethod(progress, NTuple{«c:2»,Int}) ||
+    hasmethod(progress, «t:NTuple»{«c:4»,«t:Int»}) && «k:return» progress
+    hasmethod(progress, «t:NTuple»{«c:2»,«t:Int»}) ||
         throw(ArgumentError(«s:"invalid progress callback"»))
 
     input === devnull && output !== devnull &&
@@ -474,11 +474,11 @@ running request, for example if the user wants to cancel a download.
 «f:p_func»(progress::«t:Nothing», input::«t:ArgRead», output::«t:ArgWrite») = «b:nothing»
 
 «f:arg_read_size»(path::«t:AbstractString») = filesize(path)
-«f:arg_read_size»(io::«t:Base.GenericIOBuffer») = bytesavailable(io)
+«f:arg_read_size»(io::Base.«t:GenericIOBuffer») = bytesavailable(io)
 «f:arg_read_size»(::«t:Base.DevNull») = «c:0»
 «f:arg_read_size»(::«t:Any») = «b:nothing»
 
-«k:function» «f:content_length»(headers::«t:Union{AbstractVector, AbstractDict}»)
+«k:function» «f:content_length»(headers::«t:Union»{«t:AbstractVector», «t:AbstractDict»})
     «k:for» (key, value) «k:in» headers
         «k:if» lowercase(key) == «s:"content-length"» && isa(value, AbstractString)
             «k:return» tryparse(Int, value)
@@ -497,7 +497,7 @@ running request, for example if the user wants to cancel a download.
 Set the default `Downloader`. If no argument is provided, resets the default downloader so that a fresh one is created the next time the default downloader is needed.
 """»
 «k:function» «f:default_downloader!»(
-    downloader :: «t:Union{Downloader, Nothing}» = «b:nothing»
+    downloader :: «t:Union»{«t:Downloader», «t:Nothing»} = «b:nothing»
 )
     lock(DOWNLOAD_LOCK) «k:do»
         DOWNLOADER[] = downloader
@@ -510,8 +510,8 @@ Set the default `Downloader`. If no argument is provided, resets the default dow
     «v:d» = Downloader()
     «v:f» = mktemp()[«c:1»]
     download(«s:"file://"» * f; «:julia-ts-quoted-symbol-face:downloader»=d)
-    precompile(Tuple{typeof(Downloads.download), String, String})
-    precompile(Tuple{typeof(Downloads.Curl.status_2xx_ok), Int64})
+    precompile(«t:Tuple»{typeof(Downloads.download), «t:String», «t:String»})
+    precompile(«t:Tuple»{typeof(Downloads.Curl.status_2xx_ok), «t:Int64»})
 «k:end»
 
 «k:end» «x:# module»

--- a/test/Downloads.jl.faceup
+++ b/test/Downloads.jl.faceup
@@ -1,0 +1,517 @@
+«s:"""
+The `Downloads` module exports a function [`download`](@ref), which provides cross-platform, multi-protocol,
+in-process download functionality implemented with [libcurl](https://curl.haxx.se/libcurl/).   It is used
+for the `Base.download` function in Julia 1.6 or later.
+
+More generally, the module exports functions and types that provide lower-level control and diagnostic information
+for file downloading:
+- [`download`](@ref) — download a file from a URL, erroring if it can't be downloaded
+- [`request`](@ref) — request a URL, returning a `Response` object indicating success
+- [`Response`](@ref) — a type capturing the status and other metadata about a request
+- [`RequestError`](@ref) — an error type thrown by `download` and `request` on error
+- [`Downloader`](@ref) — an object encapsulating shared resources for downloading
+"""»
+«k:module» Downloads
+
+«k:using» Base.Experimental: «:julia-ts-macro-face:@sync»
+«k:using» NetworkOptions
+«k:using» ArgTools
+
+include(«s:"Curl/Curl.jl"»)
+«k:using» .Curl
+
+«k:export» download, request, Downloader, Response, RequestError, default_downloader!
+
+«x:## public API types ##»
+
+«s:"""
+    Downloader(; [ grace::Real = 30 ])
+
+`Downloader` objects are used to perform individual `download` operations.
+Connections, name lookups and other resources are shared within a `Downloader`.
+These connections and resources are cleaned up after a configurable grace period
+(default: 30 seconds) since anything was downloaded with it, or when it is
+garbage collected, whichever comes first. If the grace period is set to zero,
+all resources will be cleaned up immediately as soon as there are no more
+ongoing downloads in progress. If the grace period is set to `Inf` then
+resources are not cleaned up until `Downloader` is garbage collected.
+"""»
+«k:mutable» «k:struct» «t:Downloader»
+    multi::«t:Multi»
+    ca_roots::«t:Union{String, Nothing}»
+    easy_hook::«t:Union{Function, Nothing}»
+
+    «f:Downloader»(multi::«t:Multi») = new(multi, get_ca_roots(), EASY_HOOK[])
+«k:end»
+«f:Downloader»(; grace::«t:Real»=«c:30») = Downloader(Multi(grace_ms(grace)))
+
+«k:function» «f:grace_ms»(grace::«t:Real»)
+    grace < «c:0» && throw(ArgumentError(«s:"grace period cannot be negative: »«:julia-ts-string-interpolation-face:$»«D:grace»«s:"»))
+    grace <= typemax(UInt64) ÷ «c:1000» ? round(UInt64, «c:1000»*grace) : typemax(UInt64)
+«k:end»
+
+«k:function» «f:easy_hook»(downloader::«t:Downloader», easy::«t:Easy», info::«t:NamedTuple»)
+    «v:hook» = downloader.easy_hook
+    hook !== «b:nothing» && Base.invokelatest(hook, easy, info)
+«k:end»
+
+«f:get_ca_roots»() = Curl.SYSTEM_SSL ? ca_roots() : ca_roots_path()
+
+«k:function» «f:set_ca_roots»(downloader::«t:Downloader», easy::«t:Easy»)
+    «v:ca_roots» = downloader.ca_roots
+    ca_roots !== «b:nothing» && set_ca_roots_path(easy, ca_roots)
+«k:end»
+
+«k:const» «v:DOWNLOAD_LOCK» = ReentrantLock()
+«k:const» «v:DOWNLOADER» = Ref{Union{Downloader, Nothing}}(«b:nothing»)
+
+«s:"""
+`EASY_HOOK` is a modifable global hook to used as the default `easy_hook` on
+new `Downloader` objects. This supplies a mechanism to set options for the
+`Downloader` via `Curl.setopt`
+
+It is expected to be function taking two arguments: an `Easy` struct and an
+`info` NamedTuple with names `url`, `method` and `headers`.
+"""»
+«k:const» «v:EASY_HOOK» = Ref{Union{Function, Nothing}}(«b:nothing»)
+
+«s:"""
+    struct Response
+        proto   :: String
+        url     :: String
+        status  :: Int
+        message :: String
+        headers :: Vector{Pair{String,String}}
+    end
+
+`Response` is a type capturing the properties of a successful response to a
+request as an object. It has the following fields:
+
+- `proto`: the protocol that was used to get the response
+- `url`: the URL that was ultimately requested after following redirects
+- `status`: the status code of the response, indicating success, failure, etc.
+- `message`: a textual message describing the nature of the response
+- `headers`: any headers that were returned with the response
+
+The meaning and availability of some of these responses depends on the protocol
+used for the request. For many protocols, including HTTP/S and S/FTP, a 2xx
+status code indicates a successful response. For responses in protocols that do
+not support headers, the headers vector will be empty. HTTP/2 does not include a
+status message, only a status code, so the message will be empty.
+"""»
+«k:struct» «t:Response»
+    proto   :: «t:Union{String, Nothing}»
+    url     :: «t:String» «x:# redirected URL»
+    status  :: «t:Int»
+    message :: «t:String»
+    headers :: «t:Vector{Pair{String,String}}»
+«k:end»
+
+Curl.«f:status_ok»(response::«t:Response») = status_ok(response.proto, response.status)
+
+«s:"""
+    struct RequestError <: ErrorException
+        url      :: String
+        code     :: Int
+        message  :: String
+        response :: Response
+    end
+
+`RequestError` is a type capturing the properties of a failed response to a
+request as an exception object:
+
+- `url`: the original URL that was requested without any redirects
+- `code`: the libcurl error code; `0` if a protocol-only error occurred
+- `message`: the libcurl error message indicating what went wrong
+- `response`: response object capturing what response info is available
+
+The same `RequestError` type is thrown by `download` if the request was
+successful but there was a protocol-level error indicated by a status code that
+is not in the 2xx range, in which case `code` will be zero and the `message`
+field will be the empty string. The `request` API only throws a `RequestError`
+if the libcurl error `code` is non-zero, in which case the included `response`
+object is likely to have a `status` of zero and an empty message. There are,
+however, situations where a curl-level error is thrown due to a protocol error,
+in which case both the inner and outer code and message may be of interest.
+"""»
+«k:struct» «t:RequestError» <: «t:Exception»
+    url      :: «t:String» «x:# original URL»
+    code     :: «t:Int»
+    message  :: «t:String»
+    response :: «t:Response»
+«k:end»
+
+«k:function» Base.«f:showerror»(io::«t:IO», err::«t:RequestError»)
+    print(io, «s:"RequestError: »«:julia-ts-string-interpolation-face:$(»«D:error_message(err)»«:julia-ts-string-interpolation-face:)»«s: while requesting »«:julia-ts-string-interpolation-face:$(»«D:err.url»«:julia-ts-string-interpolation-face:)»«s:"»)
+«k:end»
+
+«k:function» «f:error_message»(err::«t:RequestError»)
+    «v:errstr» = err.message
+    «v:status» = err.response.status
+    «v:message» = err.response.message
+    «v:status_re» = Regex(status == «c:0» ? «s:""» : «s:"\\b»«:julia-ts-string-interpolation-face:$»«D:status»«s:\\b"»)
+
+    err.code == Curl.CURLE_OK &&
+        «k:return» isempty(message) ? «s:"Error status »«:julia-ts-string-interpolation-face:$»«D:status»«s:"» :
+            contains(message, status_re) ? message :
+                «s:"»«:julia-ts-string-interpolation-face:$»«D:message»«s: (status »«:julia-ts-string-interpolation-face:$»«D:status»«s:)"»
+
+    isempty(message) && !isempty(errstr) &&
+        «k:return» status == «c:0» ? errstr : «s:"»«:julia-ts-string-interpolation-face:$»«D:errstr»«s: (status »«:julia-ts-string-interpolation-face:$»«D:status»«s:)"»
+
+    isempty(message) && («v:message» = «s:"Status »«:julia-ts-string-interpolation-face:$»«D:status»«s:"»)
+    isempty(errstr)  && («v:errstr» = «s:"curl error »«:julia-ts-string-interpolation-face:$(»«D:err.code»«:julia-ts-string-interpolation-face:)»«s:"»)
+
+    !contains(message, status_re) && !contains(errstr, status_re) &&
+        («v:errstr» = «s:"status »«:julia-ts-string-interpolation-face:$»«D:status»«s:; »«:julia-ts-string-interpolation-face:$»«D:errstr»«s:"»)
+
+    «k:return» «s:"»«:julia-ts-string-interpolation-face:$»«D:message»«s: (»«:julia-ts-string-interpolation-face:$»«D:errstr»«s:)"»
+«k:end»
+
+«x:## download API ##»
+
+«s:"""
+    download(url, [ output = tempname() ];
+        [ method = "GET", ]
+        [ headers = <none>, ]
+        [ timeout = <none>, ]
+        [ progress = <none>, ]
+        [ verbose = false, ]
+        [ debug = <none>, ]
+        [ downloader = <default>, ]
+    ) -> output
+
+        url        :: AbstractString
+        output     :: Union{AbstractString, AbstractCmd, IO}
+        method     :: AbstractString
+        headers    :: Union{AbstractVector, AbstractDict}
+        timeout    :: Real
+        progress   :: (total::Integer, now::Integer) --> Any
+        verbose    :: Bool
+        debug      :: (type, message) --> Any
+        downloader :: Downloader
+
+Download a file from the given url, saving it to `output` or if not specified, a
+temporary path. The `output` can also be an `IO` handle, in which case the body
+of the response is streamed to that handle and the handle is returned. If
+`output` is a command, the command is run and output is sent to it on stdin.
+
+If the `downloader` keyword argument is provided, it must be a `Downloader`
+object. Resources and connections will be shared between downloads performed by
+the same `Downloader` and cleaned up automatically when the object is garbage
+collected or there have been no downloads performed with it for a grace period.
+See `Downloader` for more info about configuration and usage.
+
+If the `headers` keyword argument is provided, it must be a vector or dictionary
+whose elements are all pairs of strings. These pairs are passed as headers when
+downloading URLs with protocols that supports them, such as HTTP/S.
+
+The `timeout` keyword argument specifies a timeout for the download to complete in
+seconds, with a resolution of milliseconds. By default no timeout is set, but this
+can also be explicitly requested by passing a timeout value of `Inf`. Separately,
+if 20 seconds elapse without receiving any data, the download will timeout. See
+extended help for how to disable this timeout.
+
+If the `progress` keyword argument is provided, it must be a callback function
+which will be called whenever there are updates about the size and status of the
+ongoing download. The callback must take two integer arguments: `total` and
+`now` which are the total size of the download in bytes, and the number of bytes
+which have been downloaded so far. Note that `total` starts out as zero and
+remains zero until the server gives an indication of the total size of the
+download (e.g. with a `Content-Length` header), which may never happen. So a
+well-behaved progress callback should handle a total size of zero gracefully.
+
+If the `verbose` option is set to true, `libcurl`, which is used to implement
+the download functionality will print debugging information to `stderr`. If the
+`debug` option is set to a function accepting two `String` arguments, then the
+verbose option is ignored and instead the data that would have been printed to
+`stderr` is passed to the `debug` callback with `type` and `message` arguments.
+The `type` argument indicates what kind of event has occurred, and is one of:
+`TEXT`, `HEADER IN`, `HEADER OUT`, `DATA IN`, `DATA OUT`, `SSL DATA IN` or `SSL
+DATA OUT`. The `message` argument is the description of the debug event.
+
+## Extended Help
+
+For further customization, use a [`Downloader`](@ref) and
+[`easy_hook`s](https://github.com/JuliaLang/Downloads.jl#mutual-tls-using-downloads).
+For example, to disable the 20 second timeout when no data is received, you may
+use the following:
+
+```jl
+downloader = Downloads.Downloader()
+downloader.easy_hook = (easy, info) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, 0)
+
+Downloads.download("https://httpbingo.julialang.org/delay/30"; downloader)
+```
+"""»
+«k:function» «f:download»(
+    url        :: «t:AbstractString»,
+    output     :: «t:Union{ArgWrite, Nothing}» = «b:nothing»;
+    method     :: «t:Union{AbstractString, Nothing}» = «b:nothing»,
+    headers    :: «t:Union{AbstractVector, AbstractDict}» = Pair{String,String}[],
+    timeout    :: «t:Real» = «b:Inf»,
+    progress   :: «t:Union{Function, Nothing}» = «b:nothing»,
+    verbose    :: «t:Bool» = «c:false»,
+    debug      :: «t:Union{Function, Nothing}» = «b:nothing»,
+    downloader :: «t:Union{Downloader, Nothing}» = «b:nothing»,
+) :: «t:ArgWrite»
+    arg_write(output) «k:do» output
+        «v:response» = request(
+            url,
+            «:julia-ts-quoted-symbol-face:output» = output,
+            «:julia-ts-quoted-symbol-face:method» = method,
+            «:julia-ts-quoted-symbol-face:headers» = headers,
+            «:julia-ts-quoted-symbol-face:timeout» = timeout,
+            «:julia-ts-quoted-symbol-face:progress» = progress,
+            «:julia-ts-quoted-symbol-face:verbose» = verbose,
+            «:julia-ts-quoted-symbol-face:debug» = debug,
+            «:julia-ts-quoted-symbol-face:downloader» = downloader,
+        )::«t:Response»
+        status_ok(response) && «k:return» output
+        throw(RequestError(url, Curl.CURLE_OK, «s:""», response))
+    «k:end»
+«k:end»
+
+«x:## request API ##»
+
+«s:"""
+    request(url;
+        [ input = <none>, ]
+        [ output = <none>, ]
+        [ method = input ? "PUT" : output ? "GET" : "HEAD", ]
+        [ headers = <none>, ]
+        [ timeout = <none>, ]
+        [ progress = <none>, ]
+        [ verbose = false, ]
+        [ debug = <none>, ]
+        [ throw = true, ]
+        [ downloader = <default>, ]
+        [ interrupt = <none>, ]
+    ) -> Union{Response, RequestError}
+
+        url        :: AbstractString
+        input      :: Union{AbstractString, AbstractCmd, IO}
+        output     :: Union{AbstractString, AbstractCmd, IO}
+        method     :: AbstractString
+        headers    :: Union{AbstractVector, AbstractDict}
+        timeout    :: Real
+        progress   :: (dl_total, dl_now, ul_total, ul_now) --> Any
+        verbose    :: Bool
+        debug      :: (type, message) --> Any
+        throw      :: Bool
+        downloader :: Downloader
+        interrupt  :: Base.Event
+
+Make a request to the given url, returning a `Response` object capturing the
+status, headers and other information about the response. The body of the
+response is written to `output` if specified and discarded otherwise. For HTTP/S
+requests, if an `input` stream is given, a `PUT` request is made; otherwise if
+an `output` stream is given, a `GET` request is made; if neither is given a
+`HEAD` request is made. For other protocols, appropriate default methods are
+used based on what combination of input and output are requested. The following
+options differ from the `download` function:
+
+- `input` allows providing a request body; if provided default to `PUT` request
+- `progress` is a callback taking four integers for upload and download progress
+- `throw` controls whether to throw or return a `RequestError` on request error
+
+Note that unlike `download` which throws an error if the requested URL could not
+be downloaded (indicated by non-2xx status code), `request` returns a `Response`
+object no matter what the status code of the response is. If there is an error
+with getting a response at all, then a `RequestError` is thrown or returned.
+
+If the `interrupt` keyword argument is provided, it must be a `Base.Event` object.
+If the event is triggered while the request is in progress, the request will be
+cancelled and an error will be thrown. This can be used to interrupt a long
+running request, for example if the user wants to cancel a download.
+"""»
+«k:function» «f:request»(
+    url        :: «t:AbstractString»;
+    input      :: «t:Union{ArgRead, Nothing}» = «b:nothing»,
+    output     :: «t:Union{ArgWrite, Nothing}» = «b:nothing»,
+    method     :: «t:Union{AbstractString, Nothing}» = «b:nothing»,
+    headers    :: «t:Union{AbstractVector, AbstractDict}» = Pair{String,String}[],
+    timeout    :: «t:Real» = «b:Inf»,
+    progress   :: «t:Union{Function, Nothing}» = «b:nothing»,
+    verbose    :: «t:Bool» = «c:false»,
+    debug      :: «t:Union{Function, Nothing}» = «b:nothing»,
+    throw      :: «t:Bool» = «c:true»,
+    downloader :: «t:Union{Downloader, Nothing}» = «b:nothing»,
+    interrupt  :: «t:Union{Nothing, Base.Event}» = «b:nothing»,
+) :: «t:Union{Response, RequestError}»
+    «k:if» downloader === «b:nothing»
+        lock(DOWNLOAD_LOCK) «k:do»
+            «v:downloader» = DOWNLOADER[]
+            «k:if» downloader === «b:nothing»
+                «v:downloader» = DOWNLOADER[] = Downloader()
+            «k:end»
+        «k:end»
+    «k:end»
+    «k:local» «v:response»
+    «v:have_input» = input !== «b:nothing»
+    «v:have_output» = output !== «b:nothing»
+    «v:input» = something(input, devnull)
+    «v:output» = something(output, devnull)
+    «v:input_size» = arg_read_size(input)
+    «k:if» input_size === «b:nothing»
+        «x:# take input_size from content-length header if one is supplied»
+        «v:input_size» = content_length(headers)
+    «k:end»
+    «v:progress» = p_func(progress, input, output)
+    arg_read(input) «k:do» input
+        arg_write(output) «k:do» output
+            with_handle(Easy()) «k:do» easy
+                «x:# setup the request»
+                set_url(easy, url)
+                set_timeout(easy, timeout)
+                set_verbose(easy, verbose)
+                set_debug(easy, debug)
+                add_headers(easy, headers)
+
+                «x:# libcurl does not set the default header reliably so set it»
+                «x:# explicitly unless user has specified it, xref»
+                «x:# https://github.com/JuliaLang/Pkg.jl/pull/2357»
+                «k:if» !any(kv -> lowercase(kv[«c:1»]) == «s:"user-agent"», headers)
+                    Curl.add_header(easy, «s:"User-Agent"», Curl.USER_AGENT)
+                «k:end»
+
+                «k:if» have_input
+                    enable_upload(easy)
+                    «k:if» input_size !== «b:nothing»
+                        set_upload_size(easy, input_size)
+                    «k:end»
+                    «k:if» applicable(seek, input, «c:0»)
+                        set_seeker(easy) «k:do» offset
+                            seek(input, Int(offset))
+                        «k:end»
+                    «k:end»
+                «k:else»
+                    set_body(easy, have_output && method != «s:"HEAD"»)
+                «k:end»
+                method !== «b:nothing» && set_method(easy, method)
+                progress !== «b:nothing» && enable_progress(easy)
+                set_ca_roots(downloader, easy)
+                «v:info» = (url = url, method = method, headers = headers)
+                easy_hook(downloader, easy, info)
+
+                «x:# do the request»
+                add_handle(downloader.multi, easy)
+                «v:interrupted» = Threads.Atomic{Bool}(«c:false»)
+                «k:if» interrupt !== «b:nothing»
+                    «v:interrupt_task» = «:julia-ts-macro-face:@async» «k:begin»
+                        «x:# wait for the interrupt event»
+                        wait(interrupt)
+                        «x:# cancel the request»
+                        remove_handle(downloader.multi, easy)
+                        close(easy.output)
+                        close(easy.progress)
+                        interrupted[] = «c:true»
+                        close(input)
+                        notify(easy.ready)
+                    «k:end»
+                «k:else»
+                    «v:interrupt_task» = «b:nothing»
+                «k:end»
+                «k:try» «x:# ensure handle is removed»
+                    «:julia-ts-macro-face:@sync» «k:begin»
+                        «:julia-ts-macro-face:@async» «k:for» buf «k:in» easy.output
+                            write(output, buf)
+                        «k:end»
+                        «k:if» progress !== «b:nothing»
+                            «:julia-ts-macro-face:@async» «k:for» prog «k:in» easy.progress
+                                progress(prog...)
+                            «k:end»
+                        «k:end»
+                        «k:if» have_input
+                            «:julia-ts-macro-face:@async» upload_data(easy, input)
+                        «k:end»
+                    «k:end»
+                «k:finally»
+                    «k:if» !(interrupted[])
+                        «k:if» interrupt_task !== «b:nothing»
+                            «x:# trigger interrupt»
+                            notify(interrupt)
+                            wait(interrupt_task)
+                        «k:else»
+                            remove_handle(downloader.multi, easy)
+                        «k:end»
+                    «k:end»
+                «k:end»
+
+                «x:# return the response or throw an error»
+                «v:response» = Response(get_response_info(easy)...)
+                easy.code == Curl.CURLE_OK && «k:return» response
+                «v:message» = get_curl_errstr(easy)
+                «k:if» easy.code == typemax(Curl.CURLcode)
+                    «x:# uninitialized code, likely a protocol error»
+                    «v:code» = Int(«c:0»)
+                «k:else»
+                    «v:code» = Int(easy.code)
+                «k:end»
+                «v:response» = RequestError(url, code, message, response)
+                throw && Base.throw(response)
+            «k:end»
+        «k:end»
+    «k:end»
+    «k:return» response
+«k:end»
+
+«x:## helper functions ##»
+
+«k:function» «f:p_func»(progress::«t:Function», input::«t:ArgRead», output::«t:ArgWrite»)
+    hasmethod(progress, NTuple{«c:4»,Int}) && «k:return» progress
+    hasmethod(progress, NTuple{«c:2»,Int}) ||
+        throw(ArgumentError(«s:"invalid progress callback"»))
+
+    input === devnull && output !== devnull &&
+        «k:return» (total, now, _, _) -> progress(total, now)
+    input !== devnull && output === devnull &&
+        «k:return» (_, _, total, now) -> progress(total, now)
+
+    (dl_total, dl_now, ul_total, ul_now) ->
+        progress(dl_total + ul_total, dl_now + ul_now)
+«k:end»
+«f:p_func»(progress::«t:Nothing», input::«t:ArgRead», output::«t:ArgWrite») = «b:nothing»
+
+«f:arg_read_size»(path::«t:AbstractString») = filesize(path)
+«f:arg_read_size»(io::«t:Base.GenericIOBuffer») = bytesavailable(io)
+«f:arg_read_size»(::«t:Base.DevNull») = «c:0»
+«f:arg_read_size»(::«t:Any») = «b:nothing»
+
+«k:function» «f:content_length»(headers::«t:Union{AbstractVector, AbstractDict}»)
+    «k:for» (key, value) «k:in» headers
+        «k:if» lowercase(key) == «s:"content-length"» && isa(value, AbstractString)
+            «k:return» tryparse(Int, value)
+        «k:end»
+    «k:end»
+    «k:return» «b:nothing»
+«k:end»
+
+«s:"""
+    default_downloader!(
+        downloader = <none>
+    )
+
+        downloader :: Downloader
+
+Set the default `Downloader`. If no argument is provided, resets the default downloader so that a fresh one is created the next time the default downloader is needed.
+"""»
+«k:function» «f:default_downloader!»(
+    downloader :: «t:Union{Downloader, Nothing}» = «b:nothing»
+)
+    lock(DOWNLOAD_LOCK) «k:do»
+        DOWNLOADER[] = downloader
+    «k:end»
+«k:end»
+
+«x:# Precompile»
+«k:let»
+    Curl.__init__()
+    «v:d» = Downloader()
+    «v:f» = mktemp()[«c:1»]
+    download(«s:"file://"» * f; «:julia-ts-quoted-symbol-face:downloader»=d)
+    precompile(Tuple{typeof(Downloads.download), String, String})
+    precompile(Tuple{typeof(Downloads.Curl.status_2xx_ok), Int64})
+«k:end»
+
+«k:end» «x:# module»

--- a/test/test.el
+++ b/test/test.el
@@ -1,3 +1,8 @@
+;;; test.el --- ert tests for font-locking with julia-ts-mode
+;;; Commentary:
+;; Load this package then run M-x ert RET t RET
+
+;;; Code:
 (require 'faceup)
 
 (defvar julia-font-lock-test-dir (faceup-this-file-directory))
@@ -10,5 +15,9 @@
 (faceup-defexplainer julia-font-lock-test)
 
 (ert-deftest julia-font-lock-file-test ()
-  (should (julia-font-lock-test "ArgTools.jl")
+  (should (julia-font-lock-test "ArgTools.jl"))
   (should (julia-font-lock-test "Downloads.jl"))
+  (should (julia-font-lock-test "tree-sitter-corpus.jl")))
+
+(provide 'test)
+;;; test.el ends here

--- a/test/test.el
+++ b/test/test.el
@@ -1,0 +1,14 @@
+(require 'faceup)
+
+(defvar julia-font-lock-test-dir (faceup-this-file-directory))
+
+(defun julia-font-lock-test (file)
+  "Test that the julia FILE is fontifies as the .faceup file describes."
+  (faceup-test-font-lock-file 'julia-ts-mode
+                              (concat julia-font-lock-test-dir file)))
+
+(faceup-defexplainer julia-font-lock-test)
+
+(ert-deftest julia-font-lock-file-test ()
+  (should (julia-font-lock-test "ArgTools.jl")
+  (should (julia-font-lock-test "Downloads.jl"))

--- a/test/tree-sitter-corpus.jl
+++ b/test/tree-sitter-corpus.jl
@@ -1,0 +1,784 @@
+# ==============================
+# tuple collections
+# ==============================
+
+()
+# There's no (,)
+
+(1) # NOT a tuple
+(1,)
+(2,3,4,)
+
+# ==============================
+# named tuple collections
+# ==============================
+
+(a = 1) # NOT a tuple
+(a = 1,)
+(a = 1, b = 2)
+(;)
+(; a)
+(; a = 1)
+(; a = 1, b = 2)
+(; a, foo.b)
+
+# ==============================
+# vector array collections
+# ==============================
+
+[]
+# There's no [,]
+[x]
+[x,]
+[1, 2]
+
+# Check unary-and-binary-operators
+[x.-y, 2]
+
+# ==============================
+# matrix array collections
+# ==============================
+
+[x;]
+[1 2]
+[1 2; 3 4]
+[1 2
+ 3 4]
+[1
+ 2
+ 3
+]
+[
+ a;
+ b;
+ c;
+]
+[1;; 2;; 3;;; 4;; 5;; 6;;]
+Int[1 2 3 4]
+
+# ========================================
+# comprehension array collections
+# ========================================
+
+[x for x in xs]
+[x
+  for x in xs
+  if x > 0
+]
+UInt[b(c, e) for c in d for e in f]
+
+f(1, 2, i for i in iter)
+(b(c, e) for c in d, e = 5 if e)
+
+# ==============================
+# module definitions
+# ==============================
+
+module A
+
+baremodule B end
+
+module C
+end
+
+end
+
+# ==============================
+# abstract type definitions
+# ==============================
+
+abstract type T end
+abstract type T <: S end
+abstract type T{S} <: U end
+
+# ==============================
+# primitive type definitions
+# ==============================
+
+primitive type T 8 end
+primitive type T <: S 16 end
+primitive type Ptr{T} 32 end
+
+# ==============================
+# struct definitions
+# ==============================
+
+struct Unit end
+
+struct MyInt field::Int end
+
+mutable struct Foo
+  bar
+  baz::Float64
+end
+
+# ==============================
+# parametric struct definitions
+# ==============================
+
+struct Point{T}
+  x::T
+  y::T
+end
+
+struct Rational{T<:Integer} <: Real
+  num::T
+  den::T
+end
+
+mutable struct MyVec <: AbstractArray
+  foos::Vector{Foo}
+end
+
+# ==============================
+# function definitions
+# ==============================
+
+function f end
+
+function nop() end
+
+function I(x) x end
+
+function Base.rand(n::MyInt)
+    return 4
+end
+
+function Γ(z)
+    gamma(z)
+end
+
+function ⊕(x, y)
+    x + y
+end
+
+function fix2(f, x)
+    return function(y)
+        f(x, y)
+    end
+end
+
+function (foo::Foo)()
+end
+
+# ==============================
+# short function definitions
+# ==============================
+
+s(n) = n + 1
+
+Base.foo(x) = x
+
+ι(n) = range(1, n)
+
+⊗(x, y) = x * y
+
+(+)(x, y) = x + y
+
+# ==============================
+# function definition parameters
+# ==============================
+
+function f(x, y::Int, z=1, ws...) end
+
+function (::Type{Int}, x::Int = 1, y::Int...) end
+
+function apply(f, args...; kwargs...)
+end
+
+function g(; x, y::Int, z = 1, kwargs...) nothing end
+
+# ==================================================
+# function definition return types
+# ==================================================
+
+function s(n)::MyInt
+    MyInt(n + 1)
+end
+
+function bar(f, xs::Foo.Bar)::Foo.Bar
+    map(f, xs)
+end
+
+# ==================================================
+# function definition tuple parameters
+# ==================================================
+
+function swap((x, y))
+    (y, x)
+end
+
+function f((x, y)=(1,2))
+    (x, y)
+end
+
+function car((x, y)::Tuple{T, T}) where T
+    x
+end
+
+# ==================================================
+# type parametric function definition parameters
+# ==================================================
+
+function f(x::T) where T
+end
+
+function f(n::N) where {N <: Integer}
+    n
+end
+
+f(n::N, m::M) where {N <: Number} where {M <: Integer} = n^m
+
+Foo{T}(x::T) where {T} = x
+
+function norm(p::Point{T} where T<:Real)
+    norm2(p)
+end
+
+Base.show(io::IO, ::MIME"text/plain", m::Method; kwargs...) = show_method(io, m, kwargs)
+
+# ==============================
+# macro definitions
+# ==============================
+
+macro name(s::Symbol)
+    String(s)
+end
+
+macro count(args...) length(args) end
+
+# ==============================
+# identifiers
+# ==============================
+
+abc_123_ABC
+_fn!
+ρ; φ; z
+ℝ
+x′
+θ̄
+logŷ
+ϵ
+ŷ
+🙋
+🦀
+
+# ==============================
+# field expressions
+# ==============================
+
+foo.x
+bar.x.y.z
+
+(a[1].b().c).d
+
+Base.:+
+
+df."a"
+
+# ==============================
+# index expressions
+# ==============================
+
+a[1, 2, 3]
+a[1, :]
+"foo"[1]
+
+# ==============================
+# type parametrized expressions
+# ==============================
+
+Vector{Int}
+Vector{<:Number}
+$(usertype){T}
+
+{:x} ~ normal(0, 1)
+
+# ==============================
+# function call expressions
+# ==============================
+
+f()
+g("hi", 2)
+h(d...)
+
+f(e; f = g)
+g(arg; kwarg)
+
+new{typeof(xs)}(xs)
+
+# ========================================
+# function call expressions with do blocks
+# ========================================
+
+reduce(xs) do x, y
+  f(x, y)
+end
+
+# ==============================
+# macro call expressions
+# ==============================
+
+@assert x == y "a message"
+
+@testset "a" begin
+  b = c
+end
+
+@. a * x + b
+
+joinpath(@__DIR__, "grammar.js")
+
+@macroexpand @async accept(socket)
+
+@Meta.dump 1, 2
+Meta.@dump x = 1
+
+# ==============================
+# closed macro call expressions
+# ==============================
+
+@enum(Light, red, yellow, green)
+f(@nospecialize(x)) = x
+
+@m[1, 2] + 1
+@m [1, 2] + 1
+
+# ==============================
+# quote expressions
+# ==============================
+
+:foo
+:const
+
+:(x; y)
+:(x, y)
+:[x, y, z]
+
+:+
+:->
+:(::)
+
+# ==============================
+# interpolation expressions
+# ==============================
+
+$foo
+$obj.field
+$(obj.field)
+$f(x)
+$f[1, 2]
+$"foo"
+
+using $Package: $(name)
+
+# Similar definitions in Gadfly/src/varset.jl
+mutable struct $(name)
+  $(vars...)
+end
+function $(name)($(parameters_expr))
+    $(name)($(parsed_vars...))
+end
+
+# ==============================
+# adjoint expressions
+# ==============================
+
+[u, v]'
+A'[i]
+(x, y)'
+f'(x)
+:a'
+
+# ==============================
+# juxtaposition expressions
+# ==============================
+
+1x
+2v[i]
+3f(x)
+4df.a
+5u"kg"
+x'x
+2x^2 - .3x
+2(x-1)^2 - 3(x-1)
+
+# =============================
+# arrow function expressions
+# =============================
+
+x -> x^2
+(x,y,z)-> 2*x + y - z
+()->3
+() -> (sleep(0.1); i += 1; l)
+a -> a = 2, 3
+
+# ==============================
+# boolean literals
+# ==============================
+
+true
+false
+
+# ==============================
+# integer number literals
+# ==============================
+
+0b01
+0o01234567
+0123456789
+123_456_789
+0x0123456789_abcdef_ABCDEF
+
+# ==============================
+# float number literals
+# ==============================
+
+0123456789.
+.0123456789
+0123456789.0123456789
+
+9e10
+9E-1
+9f10
+9f-1
+
+.1e10
+1.1e10
+1.e10
+
+0x0123456789_abcdef.ABCDEFp0
+0x0123456789_abcdef_ABCDEF.p-1
+0x.0123456789_abcdef_ABCDEFp1
+
+# ==============================
+# character literals
+# ==============================
+
+' '
+'o'
+'\t'
+'\uffff'
+'\U10ffff'
+
+# ==============================
+# string literals
+# ==============================
+
+""
+"\""
+"foo
+ bar"
+"this is a \"string\"."
+"""this is also a "string"."""
+band = "Interpol"
+"$band is a cool band"
+"$(2π) is a cool number"
+"cells interlinked within $("cells interlinked whithin $("cells interlinked whithin one stem")")"
+
+# ==============================
+# command string literals
+# ==============================
+
+`pwd`
+m`pwd`
+`cd $dir`
+`echo \`cmd\``
+```
+echo "\033[31mred\033[m"
+```
+
+# ==============================
+# non-standard string literals
+# ==============================
+
+# FIXME: \s shouldn't be an escape_sequence here
+trailing_ws = r"\s+$"
+version = v"1.0"
+K"\\"
+
+# ==============================
+# comments
+# ==============================
+
+# comment
+#= comment =#
+#=
+comment
+=#
+x = #= comment =# 1
+
+#=
+nested #= comments =# =#
+#==#
+
+# ==============================
+# assignment operators
+# ==============================
+
+a = b
+a .. b = a * b
+tup = 1, 2, 3
+car, cdr... = list
+c &= d ÷= e
+
+# ==============================
+# binary arithmetic operators
+# ==============================
+
+a + b
+a ++ 1 × b ⥌ 2 → c
+a // b
+x = A \ (v × w)
+
+# ==============================
+# other binary operators
+# ==============================
+
+a & b | c
+(x >>> 16, x >>> 8, x) .& 0xff
+
+Dict(b => c, d => e)
+
+x |>
+  f |>
+  g
+
+1..10
+(1:10...,)
+
+# ==============================
+# binary comparison operators
+# ==============================
+
+a === 1
+a! != 0
+
+A ⊆ B ⊆ C
+x ≥ 0 ≥ z
+
+# ==============================
+# unary operators
+# ==============================
+
+-A'
++a
+-b
+√9
+!p === !(p)
+1 ++ +2
+
+# =============================
+# operator broadcasting
+# =============================
+
+a .* b .+ c
+.~[x]
+
+# ==============================
+# ternary operator
+# ==============================
+
+x = batch_size == 1 ?
+  rand(10) :
+  rand(10, batch_size)
+
+# ==============================
+# operators as values
+# ==============================
+
+x = +
+⪯ = .≤
+print(:)
+foo(^, ÷, -)
+
+# ==============================
+# compound statements
+# ==============================
+
+begin
+end
+
+begin
+    foo
+    bar
+    baz
+end
+
+# ==============================
+# quote statements
+# ==============================
+
+quote end
+
+quote
+  x = 1
+  y = 2
+  x + y
+end
+
+# ==============================
+# let statements
+# ==============================
+
+let
+end
+
+let var1 = value1, var2, var3 = value3
+    code
+end
+
+# ==============================
+# if statements
+# ==============================
+
+if a
+elseif b
+else
+end
+
+if true 1 else 0 end
+
+if a
+  b()
+elseif c
+  d()
+  d()
+else
+  e()
+end
+
+# ==============================
+# try statements
+# ==============================
+
+try catch end
+try finally end
+
+try
+    sqrt(x)
+catch
+    sqrt(complex(x, 0))
+end
+
+try
+    operate_on_file(f)
+finally
+    close(f)
+end
+
+try
+    # fallible
+catch
+    # handle errors
+else
+    # do something if there were no exceptions
+end
+
+# ==============================
+# for statements
+# ==============================
+
+for x in xs end
+
+for x in xs foo!(x) end
+
+for i in [1, 2, 3]
+  print(i)
+end
+
+for (a, b) in c
+  print(a, b)
+end
+
+# ==============================
+# for outer statements
+# ==============================
+
+n = 1
+for outer n in range
+  body
+end
+
+for outer x = iter1, outer y = iter2
+  body
+end
+
+# ==============================
+# while statements
+# ==============================
+
+while true end
+
+while i < 5
+  print(i)
+  continue
+  break
+end
+
+while a(); b(); end
+
+# ==============================
+# return statements
+# ==============================
+
+return
+return a
+return a || b
+return a, b, c
+
+# ==============================
+# export statements
+# ==============================
+
+export a
+export a, b, +, (*)
+export @macroMcAtface
+public a
+public a, b, +, (*)
+public @macroMcAtface
+
+# ==============================
+# import statements
+# ==============================
+
+import Pkg
+
+using Sockets
+
+using ..Foo, ..Bar
+
+import CSV, Chain, DataFrames
+
+import Base: show, @kwdef, +, (*)
+
+import LinearAlgebra as la
+
+import Base: @view as @v
+
+# ===============================
+# const statements
+# ===============================
+
+const x = 5
+const y, z = 1, 2
+
+(0, const x, y = 1, 2)
+
+# ===============================
+# local statements
+# ===============================
+
+local x
+local y, z = 1, 2
+local foo() = 3
+local function bar() 4 end
+
+# ===============================
+# global statements
+# ===============================
+
+global X
+global Y, Z = 11, 42
+global foo() = 3
+global function bar() 4 end

--- a/test/tree-sitter-corpus.jl.faceup
+++ b/test/tree-sitter-corpus.jl.faceup
@@ -173,20 +173,20 @@ Base.«f:foo»(x) = x
 
 «f:⊗»(x, y) = x * y
 
-(+)(x, y) = x + y
+(«f:+»)(x, y) = x + y
 
 «x:# ==============================»
 «x:# function definition parameters»
 «x:# ==============================»
 
-«k:function» «f:f»(x, y::«t:Int», «:julia-ts-quoted-symbol-face:z»=«c:1», ws...) «k:end»
+«k:function» «f:f»(x, y::«t:Int», «:julia-ts-keyword-argument-face:z»=«c:1», ws...) «k:end»
 
 «k:function» (::«t:Type{Int}», x::«t:Int» = «c:1», y::«t:Int»...) «k:end»
 
 «k:function» «f:apply»(f, args...; kwargs...)
 «k:end»
 
-«k:function» «f:g»(; x, y::«t:Int», «:julia-ts-quoted-symbol-face:z» = «c:1», kwargs...) «b:nothing» «k:end»
+«k:function» «f:g»(; x, y::«t:Int», «:julia-ts-keyword-argument-face:z» = «c:1», kwargs...) «c:nothing» «k:end»
 
 «x:# ==================================================»
 «x:# function definition return types»
@@ -302,10 +302,10 @@ f()
 g(«s:"hi"», «c:2»)
 h(d...)
 
-f(e; «:julia-ts-quoted-symbol-face:f» = g)
+f(e; «:julia-ts-keyword-argument-face:f» = g)
 g(arg; kwarg)
 
-«k:new»{typeof(xs)}(xs)
+«t:new»{typeof(xs)}(xs)
 
 «x:# ========================================»
 «x:# function call expressions with do blocks»
@@ -368,7 +368,7 @@ Meta.«:julia-ts-macro-face:@dump» «v:x» = «c:1»
 «:julia-ts-interpolation-expression-face:$(»«D:obj.field»«:julia-ts-interpolation-expression-face:)»
 «:julia-ts-interpolation-expression-face:$»«D:f»(x)
 «:julia-ts-interpolation-expression-face:$»«D:f»[«c:1», «c:2»]
-$«s:"foo"»
+«:julia-ts-interpolation-expression-face:$»«s:"foo"»
 
 «k:using» «:julia-ts-interpolation-expression-face:$»«D:Package»: «:julia-ts-interpolation-expression-face:$(»«D:name»«:julia-ts-interpolation-expression-face:)»
 
@@ -517,7 +517,7 @@ nested #= comments =# =#»
 «x:# ==============================»
 
 «v:a» = b
-a .. b = a * b
+a «f:..» b = a * b
 «v:tup» = «c:1», «c:2», «c:3»
 «v:car», cdr... = list
 c &= d ÷= e
@@ -588,7 +588,7 @@ a .* b .+ c
 «x:# ==============================»
 
 «v:x» = +
-⪯ = .≤
+«v:⪯» = .≤
 print(:)
 foo(^, ÷, -)
 

--- a/test/tree-sitter-corpus.jl.faceup
+++ b/test/tree-sitter-corpus.jl.faceup
@@ -1,0 +1,784 @@
+«x:# ==============================»
+«x:# tuple collections»
+«x:# ==============================»
+
+()
+«x:# There's no (,)»
+
+(«c:1») «x:# NOT a tuple»
+(«c:1»,)
+(«c:2»,«c:3»,«c:4»,)
+
+«x:# ==============================»
+«x:# named tuple collections»
+«x:# ==============================»
+
+(«v:a» = «c:1») «x:# NOT a tuple»
+(a = «c:1»,)
+(a = «c:1», b = «c:2»)
+(;)
+(; a)
+(; a = «c:1»)
+(; a = «c:1», b = «c:2»)
+(; a, foo.b)
+
+«x:# ==============================»
+«x:# vector array collections»
+«x:# ==============================»
+
+[]
+«x:# There's no [,]»
+[x]
+[x,]
+[«c:1», «c:2»]
+
+«x:# Check unary-and-binary-operators»
+[x.-y, «c:2»]
+
+«x:# ==============================»
+«x:# matrix array collections»
+«x:# ==============================»
+
+[x;]
+[«c:1» «c:2»]
+[«c:1» «c:2»; «c:3» «c:4»]
+[«c:1» «c:2»
+ «c:3» «c:4»]
+[«c:1»
+ «c:2»
+ «c:3»
+]
+[
+ a;
+ b;
+ c;
+]
+[«c:1»;; «c:2»;; «c:3»;;; «c:4»;; «c:5»;; «c:6»;;]
+Int[«c:1» «c:2» «c:3» «c:4»]
+
+«x:# ========================================»
+«x:# comprehension array collections»
+«x:# ========================================»
+
+[x «k:for» x «k:in» xs]
+[x
+  «k:for» x «k:in» xs
+  «k:if» x > «c:0»
+]
+UInt[b(c, e) «k:for» c «k:in» d «k:for» e «k:in» f]
+
+f(«c:1», «c:2», i «k:for» i «k:in» iter)
+(b(c, e) «k:for» c «k:in» d, e = «c:5» «k:if» e)
+
+«x:# ==============================»
+«x:# module definitions»
+«x:# ==============================»
+
+«k:module» A
+
+«k:baremodule» B «k:end»
+
+«k:module» C
+«k:end»
+
+«k:end»
+
+«x:# ==============================»
+«x:# abstract type definitions»
+«x:# ==============================»
+
+«k:abstract» «k:type» «t:T» «k:end»
+«k:abstract» «k:type» «t:T» <: «t:S» «k:end»
+«k:abstract» «k:type» «t:T»{«t:S»} <: «t:U» «k:end»
+
+«x:# ==============================»
+«x:# primitive type definitions»
+«x:# ==============================»
+
+«k:primitive» «k:type» «t:T» «c:8» «k:end»
+«k:primitive» «k:type» «t:T» <: «t:S» «c:16» «k:end»
+«k:primitive» «k:type» «t:Ptr»{«t:T»} «c:32» «k:end»
+
+«x:# ==============================»
+«x:# struct definitions»
+«x:# ==============================»
+
+«k:struct» «t:Unit» «k:end»
+
+«k:struct» «t:MyInt» field::«t:Int» «k:end»
+
+«k:mutable» «k:struct» «t:Foo»
+  bar
+  baz::«t:Float64»
+«k:end»
+
+«x:# ==============================»
+«x:# parametric struct definitions»
+«x:# ==============================»
+
+«k:struct» «t:Point»{«t:T»}
+  x::«t:T»
+  y::«t:T»
+«k:end»
+
+«k:struct» «t:Rational»{«t:T»<:«t:Integer»} <: «t:Real»
+  num::«t:T»
+  den::«t:T»
+«k:end»
+
+«k:mutable» «k:struct» «t:MyVec» <: «t:AbstractArray»
+  foos::«t:Vector»{«t:Foo»}
+«k:end»
+
+«x:# ==============================»
+«x:# function definitions»
+«x:# ==============================»
+
+«k:function» «f:f» «k:end»
+
+«k:function» «f:nop»() «k:end»
+
+«k:function» «f:I»(x) x «k:end»
+
+«k:function» Base.«f:rand»(n::«t:MyInt»)
+    «k:return» «c:4»
+«k:end»
+
+«k:function» «f:Γ»(z)
+    gamma(z)
+«k:end»
+
+«k:function» «f:⊕»(x, y)
+    x + y
+«k:end»
+
+«k:function» «f:fix2»(f, x)
+    «k:return» «k:function»(y)
+        f(x, y)
+    «k:end»
+«k:end»
+
+«k:function» (foo::«t:Foo»)()
+«k:end»
+
+«x:# ==============================»
+«x:# short function definitions»
+«x:# ==============================»
+
+«f:s»(n) = n + «c:1»
+
+Base.«f:foo»(x) = x
+
+«f:ι»(n) = range(«c:1», n)
+
+«f:⊗»(x, y) = x * y
+
+(+)(x, y) = x + y
+
+«x:# ==============================»
+«x:# function definition parameters»
+«x:# ==============================»
+
+«k:function» «f:f»(x, y::«t:Int», «:julia-ts-quoted-symbol-face:z»=«c:1», ws...) «k:end»
+
+«k:function» (::«t:Type{Int}», x::«t:Int» = «c:1», y::«t:Int»...) «k:end»
+
+«k:function» «f:apply»(f, args...; kwargs...)
+«k:end»
+
+«k:function» «f:g»(; x, y::«t:Int», «:julia-ts-quoted-symbol-face:z» = «c:1», kwargs...) «b:nothing» «k:end»
+
+«x:# ==================================================»
+«x:# function definition return types»
+«x:# ==================================================»
+
+«k:function» «f:s»(n)::«t:MyInt»
+    MyInt(n + «c:1»)
+«k:end»
+
+«k:function» «f:bar»(f, xs::Foo.«t:Bar»)::Foo.«t:Bar»
+    map(f, xs)
+«k:end»
+
+«x:# ==================================================»
+«x:# function definition tuple parameters»
+«x:# ==================================================»
+
+«k:function» «f:swap»((x, y))
+    (y, x)
+«k:end»
+
+«k:function» «f:f»((x, y)=(«c:1»,«c:2»))
+    (x, y)
+«k:end»
+
+«k:function» «f:car»((x, y)::«t:Tuple»{«t:T», «t:T»}) «k:where» «t:T»
+    x
+«k:end»
+
+«x:# ==================================================»
+«x:# type parametric function definition parameters»
+«x:# ==================================================»
+
+«k:function» «f:f»(x::«t:T») «k:where» «t:T»
+«k:end»
+
+«k:function» «f:f»(n::«t:N») «k:where» {«t:N» <: «t:Integer»}
+    n
+«k:end»
+
+f(n::«t:N», m::«t:M») «k:where» {«t:N» <: «t:Number»} «k:where» {«t:M» <: «t:Integer»} = n^m
+
+«t:Foo»{«t:T»}(x::«t:T») «k:where» {«t:T»} = x
+
+«k:function» «f:norm»(p::«t:Point»{«t:T»} «k:where» T<:Real)
+    norm2(p)
+«k:end»
+
+Base.«f:show»(io::«t:IO», ::«t:MIME"text/plain"», m::«t:Method»; kwargs...) = show_method(io, m, kwargs)
+
+«x:# ==============================»
+«x:# macro definitions»
+«x:# ==============================»
+
+«k:macro» «f:name»(s::«t:Symbol»)
+    String(s)
+«k:end»
+
+«k:macro» «f:count»(args...) length(args) «k:end»
+
+«x:# ==============================»
+«x:# identifiers»
+«x:# ==============================»
+
+abc_123_ABC
+_fn!
+ρ; φ; z
+ℝ
+x′
+θ̄
+logŷ
+ϵ
+ŷ
+🙋
+🦀
+
+«x:# ==============================»
+«x:# field expressions»
+«x:# ==============================»
+
+foo.x
+bar.x.y.z
+
+(a[«c:1»].b().c).d
+
+Base.«:julia-ts-quoted-symbol-face::+»
+
+df.«s:"a"»
+
+«x:# ==============================»
+«x:# index expressions»
+«x:# ==============================»
+
+a[«c:1», «c:2», «c:3»]
+a[«c:1», :]
+«s:"foo"»[«c:1»]
+
+«x:# ==============================»
+«x:# type parametrized expressions»
+«x:# ==============================»
+
+«t:Vector»{«t:Int»}
+«t:Vector»{<:«t:Number»}
+«:julia-ts-interpolation-expression-face:$(»«D:usertype»«:julia-ts-interpolation-expression-face:)»{«t:T»}
+
+{«:julia-ts-quoted-symbol-face::x»} ~ normal(«c:0», «c:1»)
+
+«x:# ==============================»
+«x:# function call expressions»
+«x:# ==============================»
+
+f()
+g(«s:"hi"», «c:2»)
+h(d...)
+
+f(e; «:julia-ts-quoted-symbol-face:f» = g)
+g(arg; kwarg)
+
+«k:new»{typeof(xs)}(xs)
+
+«x:# ========================================»
+«x:# function call expressions with do blocks»
+«x:# ========================================»
+
+reduce(xs) «k:do» x, y
+  f(x, y)
+«k:end»
+
+«x:# ==============================»
+«x:# macro call expressions»
+«x:# ==============================»
+
+«:julia-ts-macro-face:@assert» x == y «s:"a message"»
+
+«:julia-ts-macro-face:@testset» «s:"a"» «k:begin»
+  «v:b» = c
+«k:end»
+
+«:julia-ts-macro-face:@.» a * x + b
+
+joinpath(«:julia-ts-macro-face:@__DIR__», «s:"grammar.js"»)
+
+«:julia-ts-macro-face:@macroexpand» «:julia-ts-macro-face:@async» accept(socket)
+
+«:julia-ts-macro-face:@Meta.dump» «c:1», «c:2»
+Meta.«:julia-ts-macro-face:@dump» «v:x» = «c:1»
+
+«x:# ==============================»
+«x:# closed macro call expressions»
+«x:# ==============================»
+
+«:julia-ts-macro-face:@enum»(Light, red, yellow, green)
+«f:f»(«:julia-ts-macro-face:@nospecialize»(x)) = x
+
+«:julia-ts-macro-face:@m»[«c:1», «c:2»] + «c:1»
+«:julia-ts-macro-face:@m» [«c:1», «c:2»] + «c:1»
+
+«x:# ==============================»
+«x:# quote expressions»
+«x:# ==============================»
+
+«:julia-ts-quoted-symbol-face::foo»
+«:julia-ts-quoted-symbol-face::const»
+
+«:julia-ts-quoted-symbol-face::(x; y)»
+«:julia-ts-quoted-symbol-face::(x, y)»
+«:julia-ts-quoted-symbol-face::[x, y, z]»
+
+«:julia-ts-quoted-symbol-face::+»
+«:julia-ts-quoted-symbol-face::->»
+«:julia-ts-quoted-symbol-face::(::)»
+
+«x:# ==============================»
+«x:# interpolation expressions»
+«x:# ==============================»
+
+«:julia-ts-interpolation-expression-face:$»«D:foo»
+«:julia-ts-interpolation-expression-face:$»«D:obj».field
+«:julia-ts-interpolation-expression-face:$(»«D:obj.field»«:julia-ts-interpolation-expression-face:)»
+«:julia-ts-interpolation-expression-face:$»«D:f»(x)
+«:julia-ts-interpolation-expression-face:$»«D:f»[«c:1», «c:2»]
+$«s:"foo"»
+
+«k:using» «:julia-ts-interpolation-expression-face:$»«D:Package»: «:julia-ts-interpolation-expression-face:$(»«D:name»«:julia-ts-interpolation-expression-face:)»
+
+«x:# Similar definitions in Gadfly/src/varset.jl»
+«k:mutable» «k:struct» «:julia-ts-interpolation-expression-face:$(»«D:name»«:julia-ts-interpolation-expression-face:)»
+  «:julia-ts-interpolation-expression-face:$(»«D:vars...»«:julia-ts-interpolation-expression-face:)»
+«k:end»
+«k:function» «:julia-ts-interpolation-expression-face:$(»«D:name»«:julia-ts-interpolation-expression-face:)»(«:julia-ts-interpolation-expression-face:$(»«D:parameters_expr»«:julia-ts-interpolation-expression-face:)»)
+    «:julia-ts-interpolation-expression-face:$(»«D:name»«:julia-ts-interpolation-expression-face:)»(«:julia-ts-interpolation-expression-face:$(»«D:parsed_vars...»«:julia-ts-interpolation-expression-face:)»)
+«k:end»
+
+«x:# ==============================»
+«x:# adjoint expressions»
+«x:# ==============================»
+
+[u, v]'
+A'[i]
+(x, y)'
+f'(x)
+«:julia-ts-quoted-symbol-face::a»'
+
+«x:# ==============================»
+«x:# juxtaposition expressions»
+«x:# ==============================»
+
+«c:1»x
+«c:2»v[i]
+«c:3»f(x)
+«c:4»df.a
+«c:5»«s:u"kg"»
+x'x
+«c:2»x^«c:2» - «c:.3»x
+«c:2»(x-«c:1»)^«c:2» - «c:3»(x-«c:1»)
+
+«x:# =============================»
+«x:# arrow function expressions»
+«x:# =============================»
+
+x -> x^«c:2»
+(x,y,z)-> «c:2»*x + y - z
+()->«c:3»
+() -> (sleep(«c:0.1»); i += «c:1»; l)
+a -> «v:a» = «c:2», «c:3»
+
+«x:# ==============================»
+«x:# boolean literals»
+«x:# ==============================»
+
+«c:true»
+«c:false»
+
+«x:# ==============================»
+«x:# integer number literals»
+«x:# ==============================»
+
+«c:0b01»
+«c:0o01234567»
+«c:0123456789»
+«c:123_456_789»
+«c:0x0123456789_abcdef_ABCDEF»
+
+«x:# ==============================»
+«x:# float number literals»
+«x:# ==============================»
+
+«c:0123456789.»
+«c:.0123456789»
+«c:0123456789.0123456789»
+
+«c:9e10»
+«c:9E-1»
+«c:9f10»
+«c:9f-1»
+
+«c:.1e10»
+«c:1.1e10»
+«c:1.e10»
+
+«c:0x0123456789_abcdef.ABCDEFp0»
+«c:0x0123456789_abcdef_ABCDEF.p-1»
+«c:0x.0123456789_abcdef_ABCDEFp1»
+
+«x:# ==============================»
+«x:# character literals»
+«x:# ==============================»
+
+«c:' '»
+«c:'o'»
+«c:'\t'»
+«c:'\uffff'»
+«c:'\U10ffff'»
+
+«x:# ==============================»
+«x:# string literals»
+«x:# ==============================»
+
+«s:""»
+«s:"\""»
+«s:"foo
+ bar"»
+«s:"this is a \"string\"."»
+«s:"""this is also a "string"."""»
+«v:band» = «s:"Interpol"»
+«s:"»«:julia-ts-string-interpolation-face:$»«D:band»«s: is a cool band"»
+«s:"»«:julia-ts-string-interpolation-face:$(»«c:2»«D:π»«:julia-ts-string-interpolation-face:)»«s: is a cool number"»
+«s:"cells interlinked within »«:julia-ts-string-interpolation-face:$(»«D:"cells interlinked whithin »«:julia-ts-string-interpolation-face:$(»«D:"cells interlinked whithin one stem"»«:julia-ts-string-interpolation-face:)»«D:"»«:julia-ts-string-interpolation-face:)»«s:"»
+
+«x:# ==============================»
+«x:# command string literals»
+«x:# ==============================»
+
+«s:`pwd`»
+«s:m`pwd`»
+«s:`cd »«:julia-ts-string-interpolation-face:$»«D:dir»«s:`»
+«s:`echo \`cmd\``»
+«s:```
+echo "\033[31mred\033[m"
+```»
+
+«x:# ==============================»
+«x:# non-standard string literals»
+«x:# ==============================»
+
+«x:# FIXME: \s shouldn't be an escape_sequence here»
+«v:trailing_ws» = «s:r"\s+$"»
+«v:version» = «s:v"1.0"»
+«s:K"\\"»
+
+«x:# ==============================»
+«x:# comments»
+«x:# ==============================»
+
+«x:# comment»
+«x:#= comment =#»
+«x:#=
+comment
+=#»
+«v:x» = «x:#= comment =#» «c:1»
+
+«x:#=
+nested #= comments =# =#»
+«x:#==#»
+
+«x:# ==============================»
+«x:# assignment operators»
+«x:# ==============================»
+
+«v:a» = b
+a .. b = a * b
+«v:tup» = «c:1», «c:2», «c:3»
+«v:car», cdr... = list
+c &= d ÷= e
+
+«x:# ==============================»
+«x:# binary arithmetic operators»
+«x:# ==============================»
+
+a + b
+a ++ «c:1» × b ⥌ «c:2» → c
+a // b
+«v:x» = A \ (v × w)
+
+«x:# ==============================»
+«x:# other binary operators»
+«x:# ==============================»
+
+a & b | c
+(x >>> «c:16», x >>> «c:8», x) .& «c:0xff»
+
+Dict(b => c, d => e)
+
+x |>
+  f |>
+  g
+
+«c:1»..«c:10»
+(«c:1»:«c:10»...,)
+
+«x:# ==============================»
+«x:# binary comparison operators»
+«x:# ==============================»
+
+a === «c:1»
+a! != «c:0»
+
+A ⊆ B ⊆ C
+x ≥ «c:0» ≥ z
+
+«x:# ==============================»
+«x:# unary operators»
+«x:# ==============================»
+
+-A'
++a
+-b
+√«c:9»
+!p === !(p)
+«c:1» ++ +«c:2»
+
+«x:# =============================»
+«x:# operator broadcasting»
+«x:# =============================»
+
+a .* b .+ c
+.~[x]
+
+«x:# ==============================»
+«x:# ternary operator»
+«x:# ==============================»
+
+«v:x» = batch_size == «c:1» ?
+  rand(«c:10») :
+  rand(«c:10», batch_size)
+
+«x:# ==============================»
+«x:# operators as values»
+«x:# ==============================»
+
+«v:x» = +
+⪯ = .≤
+print(:)
+foo(^, ÷, -)
+
+«x:# ==============================»
+«x:# compound statements»
+«x:# ==============================»
+
+«k:begin»
+«k:end»
+
+«k:begin»
+    foo
+    bar
+    baz
+«k:end»
+
+«x:# ==============================»
+«x:# quote statements»
+«x:# ==============================»
+
+«k:quote» «k:end»
+
+«k:quote»
+  «v:x» = «c:1»
+  «v:y» = «c:2»
+  x + y
+«k:end»
+
+«x:# ==============================»
+«x:# let statements»
+«x:# ==============================»
+
+«k:let»
+«k:end»
+
+«k:let» «v:var1» = value1, «v:var2», «v:var3» = value3
+    code
+«k:end»
+
+«x:# ==============================»
+«x:# if statements»
+«x:# ==============================»
+
+«k:if» a
+«k:elseif» b
+«k:else»
+«k:end»
+
+«k:if» «c:true» «c:1» «k:else» «c:0» «k:end»
+
+«k:if» a
+  b()
+«k:elseif» c
+  d()
+  d()
+«k:else»
+  e()
+«k:end»
+
+«x:# ==============================»
+«x:# try statements»
+«x:# ==============================»
+
+«k:try» «k:catch» «k:end»
+«k:try» «k:finally» «k:end»
+
+«k:try»
+    sqrt(x)
+«k:catch»
+    sqrt(complex(x, «c:0»))
+«k:end»
+
+«k:try»
+    operate_on_file(f)
+«k:finally»
+    close(f)
+«k:end»
+
+«k:try»
+    «x:# fallible»
+«k:catch»
+    «x:# handle errors»
+«k:else»
+    «x:# do something if there were no exceptions»
+«k:end»
+
+«x:# ==============================»
+«x:# for statements»
+«x:# ==============================»
+
+«k:for» x «k:in» xs «k:end»
+
+«k:for» x «k:in» xs foo!(x) «k:end»
+
+«k:for» i «k:in» [«c:1», «c:2», «c:3»]
+  print(i)
+«k:end»
+
+«k:for» (a, b) «k:in» c
+  print(a, b)
+«k:end»
+
+«x:# ==============================»
+«x:# for outer statements»
+«x:# ==============================»
+
+«v:n» = «c:1»
+«k:for» «k:outer» n «k:in» range
+  body
+«k:end»
+
+«k:for» «k:outer» x = iter1, «k:outer» y = iter2
+  body
+«k:end»
+
+«x:# ==============================»
+«x:# while statements»
+«x:# ==============================»
+
+«k:while» «c:true» «k:end»
+
+«k:while» i < «c:5»
+  print(i)
+  «k:continue»
+  «k:break»
+«k:end»
+
+«k:while» a(); b(); «k:end»
+
+«x:# ==============================»
+«x:# return statements»
+«x:# ==============================»
+
+«k:return»
+«k:return» a
+«k:return» a || b
+«k:return» a, b, c
+
+«x:# ==============================»
+«x:# export statements»
+«x:# ==============================»
+
+«k:export» a
+«k:export» a, b, +, (*)
+«k:export» «:julia-ts-macro-face:@macroMcAtface»
+«k:public» a
+«k:public» a, b, +, (*)
+«k:public» «:julia-ts-macro-face:@macroMcAtface»
+
+«x:# ==============================»
+«x:# import statements»
+«x:# ==============================»
+
+«k:import» Pkg
+
+«k:using» Sockets
+
+«k:using» ..Foo, ..Bar
+
+«k:import» CSV, Chain, DataFrames
+
+«k:import» Base: show, «:julia-ts-macro-face:@kwdef», +, (*)
+
+«k:import» LinearAlgebra as la
+
+«k:import» Base: «:julia-ts-macro-face:@view» as «:julia-ts-macro-face:@v»
+
+«x:# ===============================»
+«x:# const statements»
+«x:# ===============================»
+
+«k:const» «v:x» = «c:5»
+«k:const» «v:y», «v:z» = «c:1», «c:2»
+
+(«c:0», «k:const» «v:x», «v:y» = «c:1», «c:2»)
+
+«x:# ===============================»
+«x:# local statements»
+«x:# ===============================»
+
+«k:local» «v:x»
+«k:local» «v:y», «v:z» = «c:1», «c:2»
+«k:local» «f:foo»() = «c:3»
+«k:local» «k:function» «f:bar»() «c:4» «k:end»
+
+«x:# ===============================»
+«x:# global statements»
+«x:# ===============================»
+
+«k:global» «v:X»
+«k:global» «v:Y», «v:Z» = «c:11», «c:42»
+«k:global» «f:foo»() = «c:3»
+«k:global» «k:function» «f:bar»() «c:4» «k:end»


### PR DESCRIPTION
1. Fix grammar after the Julia tree-sitter grammar has been changed in https://github.com/tree-sitter/tree-sitter-julia/pull/135

2. Adjust syntax highlight of interpolations: use syntax information of interpolated code to highlight parts of it.

3. Highlight keyword argument names as symbols.