### PR TITLE
Various improvements to fontification + CI workflow with autotest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,10 @@ jobs:
           - 29.2
           - 29.3
           - 29.4
+          - 30.1
+          - 30.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Emacs
         uses: purcell/setup-emacs@master
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,41 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version:
+          - 29.1
+          - 29.2
+          - 29.3
+          - 29.4
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+      - name: Install prerequisites
+        shell: emacs --script {0}
+        run: |
+          (package-install 'julia-mode t)
+          (add-to-list 'load-path "${{ github.workspace }}")
+          (require 'julia-ts-mode)
+          (treesit-install-language-grammar 'julia)
+      - name: MELPA checks
+        uses: leotaku/elisp-check@master
+        with:
+          check: melpa
+          file: julia-ts-mode.el
+      - name: ERT checks
+        uses: leotaku/elisp-check@master
+        with:
+          check: ert
+          file: test/test.el

--- a/julia-ts-mode.el
+++ b/julia-ts-mode.el
@@ -31,7 +31,7 @@
 ;;
 ;;; Commentary:
 ;; This major modes uses tree-sitter for font-lock, indentation, imenu, and
-;; navigation. It is derived from `julia-mode'.
+;; navigation.  It is derived from `julia-mode'.
 
 ;;;; Code:
 
@@ -53,6 +53,13 @@
   :prefix "julia-ts-")
 ;; Notice that all custom variables and faces are automatically added to the
 ;; most recent group.
+
+;; As of the grammar version 0.22, it uses the argument_list node for both
+;; function definitions and calls.
+(define-obsolete-variable-alias
+  'julia-ts-align-parameter-list-to-first-sibling
+  'julia-ts-align-argument-list-to-first-sibling
+  "0.3")
 
 (defcustom julia-ts-align-argument-list-to-first-sibling nil
   "Align the argument list to the first sibling.
@@ -86,13 +93,6 @@ Otherwise, the indentation is:
   :version "29.1"
   :type 'boolean)
 
-;; As of the grammar version 0.22, it uses the argument_list node for both
-;; function definitions and calls.
-(define-obsolete-variable-alias
-  'julia-ts-align-parameter-list-to-first-sibling
-  'julia-ts-align-argument-list-to-first-sibling
-  "0.3")
-
 (defcustom julia-ts-align-curly-brace-expressions-to-first-sibling nil
   "Align curly brace expressions to the first sibling.
 
@@ -120,7 +120,7 @@ Otherwise, the indentation is:
 
 (defface julia-ts-quoted-symbol-face
   '((t :inherit font-lock-constant-face))
-  "Face for quoted Julia symbols in `julia-ts-mode', e.g. :foo.")
+  "Face for quoted Julia symbols in `julia-ts-mode', e.g., :foo.")
 
 (defface julia-ts-keyword-argument-face
   '((t :inherit font-lock-constant-face))
@@ -128,11 +128,11 @@ Otherwise, the indentation is:
 
 (defface julia-ts-interpolation-expression-face
   '((t :inherit font-lock-constant-face))
-  "Face for interpolation expressions in `julia-ts-mode', e.g. $foo.")
+  "Face for interpolation expressions in `julia-ts-mode', e.g., $foo.")
 
 (defface julia-ts-string-interpolation-face
   '((t :inherit font-lock-constant-face :weight bold))
-  "Face for string interpolations in `julia-ts-mode', e.g. \"$foo\".")
+  "Face for string interpolations in `julia-ts-mode', e.g., \"$foo\".")
 
 (defvar julia-ts--keywords
   '("baremodule" "begin" "catch" "const" "do" "else" "elseif" "end" "export"

--- a/test/Downloads.jl.faceup
+++ b/test/Downloads.jl.faceup
@@ -149,7 +149,7 @@ in which case both the inner and outer code and message may be of interest.
     «v:errstr» = err.message
     «v:status» = err.response.status
     «v:message» = err.response.message
-    «v:status_re» = Regex(status == «c:0» ? «s:""» : «s:"\\b»«:julia-ts-string-interpolation-face:$»«D:status»«s:\\b"»)
+    «v:status_re» = Regex(status == «c:0» ? «s:""» : «s:"»«:font-lock-escape-face:\\»«s:b»«:julia-ts-string-interpolation-face:$»«D:status»«:font-lock-escape-face:\\»«s:b"»)
 
     err.code == Curl.CURLE_OK &&
         «k:return» isempty(message) ? «s:"Error status »«:julia-ts-string-interpolation-face:$»«D:status»«s:"» :

--- a/test/test.el
+++ b/test/test.el
@@ -4,6 +4,7 @@
 
 ;;; Code:
 (require 'faceup)
+(require 'julia-ts-mode)
 
 (defvar julia-font-lock-test-dir (faceup-this-file-directory))
 

--- a/test/tree-sitter-corpus.jl
+++ b/test/tree-sitter-corpus.jl
@@ -492,7 +492,6 @@ echo "\033[31mred\033[m"
 # non-standard string literals
 # ==============================
 
-# FIXME: \s shouldn't be an escape_sequence here
 trailing_ws = r"\s+$"
 version = v"1.0"
 K"\\"
@@ -521,6 +520,17 @@ a .. b = a * b
 tup = 1, 2, 3
 car, cdr... = list
 c &= d ÷= e
+
+# open tuple
+a, b = 1, 2
+# regular tuple
+(a, b) = (1, 2)
+# typed assignment
+a::Int = 1
+# FQN
+Main.a = 12
+# combination
+a::Int, b::Int... = 1, 2, 3
 
 # ==============================
 # binary arithmetic operators

--- a/test/tree-sitter-corpus.jl.faceup
+++ b/test/tree-sitter-corpus.jl.faceup
@@ -227,7 +227,7 @@ Base.«f:foo»(x) = x
     n
 «k:end»
 
-f(n::«t:N», m::«t:M») «k:where» {«t:N» <: «t:Number»} «k:where» {«t:M» <: «t:Integer»} = n^m
+«f:f»(n::«t:N», m::«t:M») «k:where» {«t:N» <: «t:Number»} «k:where» {«t:M» <: «t:Integer»} = n^m
 
 «t:Foo»{«t:T»}(x::«t:T») «k:where» {«t:T»} = x
 
@@ -466,10 +466,10 @@ a -> «v:a» = «c:2», «c:3»
 «x:# ==============================»
 
 «s:""»
-«s:"\""»
+«s:"»«:font-lock-escape-face:\"»«s:"»
 «s:"foo
  bar"»
-«s:"this is a \"string\"."»
+«s:"this is a »«:font-lock-escape-face:\"»«s:string»«:font-lock-escape-face:\"»«s:."»
 «s:"""this is also a "string"."""»
 «v:band» = «s:"Interpol"»
 «s:"»«:julia-ts-string-interpolation-face:$»«D:band»«s: is a cool band"»
@@ -483,19 +483,18 @@ a -> «v:a» = «c:2», «c:3»
 «s:`pwd`»
 «s:m`pwd`»
 «s:`cd »«:julia-ts-string-interpolation-face:$»«D:dir»«s:`»
-«s:`echo \`cmd\``»
+«s:`echo »«:font-lock-escape-face:\`»«s:cmd»«:font-lock-escape-face:\`»«s:`»
 «s:```
-echo "\033[31mred\033[m"
+echo "»«:font-lock-escape-face:\033»«s:[31mred»«:font-lock-escape-face:\033»«s:[m"
 ```»
 
 «x:# ==============================»
 «x:# non-standard string literals»
 «x:# ==============================»
 
-«x:# FIXME: \s shouldn't be an escape_sequence here»
-«v:trailing_ws» = «s:r"\s+$"»
+«v:trailing_ws» = «:font-lock-regexp-face:r"\s+$"»
 «v:version» = «s:v"1.0"»
-«s:K"\\"»
+«s:K"»«:font-lock-escape-face:\\»«s:"»
 
 «x:# ==============================»
 «x:# comments»
@@ -519,8 +518,19 @@ nested #= comments =# =#»
 «v:a» = b
 a «f:..» b = a * b
 «v:tup» = «c:1», «c:2», «c:3»
-«v:car», cdr... = list
+«v:car», «v:cdr»... = list
 c &= d ÷= e
+
+«x:# open tuple»
+«v:a», «v:b» = «c:1», «c:2»
+«x:# regular tuple»
+(«v:a», «v:b») = («c:1», «c:2»)
+«x:# typed assignment»
+«v:a»::«t:Int» = «c:1»
+«x:# FQN»
+Main.«v:a» = «c:12»
+«x:# combination»
+«v:a»::«t:Int», «v:b»::«t:Int»... = «c:1», «c:2», «c:3»
 
 «x:# ==============================»
 «x:# binary arithmetic operators»


### PR DESCRIPTION
1. correctly fontify escape sequences and regex strings;

2. correctly fontify tuple assigments;

3. make function definition name fontification significantly simpler and more robust, fontify more obscure variants correctly;

4. fontify variable assignments in a few more scenarios: typed assignments and slurps;

5. add GitHub CI workflow to run various tests (MELPA + ERT);